### PR TITLE
feat: implement filesystem-safe worktree directory naming

### DIFF
--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -14,7 +14,7 @@ This document tracks the systematic implementation of code quality improvements 
 | 6 | Add Progress Indicators | ⏳ Pending | High | 4 hours |
 | 7 | Add Retry Mechanisms | ✅ Complete | High | 3 hours |
 | 8 | Increase Test Coverage | ⏳ Pending | High | 1 day |
-| 9 | Implement Filesystem-Safe Worktree Directory Naming | ⏳ Pending | Medium | 2-3 hours |
+| 9 | Implement Filesystem-Safe Worktree Directory Naming | ✅ Complete | Medium | 2-3 hours |
 
 ## Implementation Details
 
@@ -259,6 +259,14 @@ func CreateWorktreeWithSafeNaming(branchName string, basePath string) error {
 - Test edge cases like multiple slashes, dots, and other special characters
 - Ensure proper branch creation with intended branch names
 - Validate directory structure follows filesystem conventions
+
+**✅ Status**: **COMPLETE** - Implementation finished with comprehensive tests
+- Created `internal/git/naming.go` with `BranchToDirectoryName()` function
+- Created `internal/git/worktree.go` with enhanced worktree creation functions
+- Updated `internal/commands/init.go` to use safe naming in `CreateAdditionalWorktrees`
+- Updated `internal/git/operations.go` to use safe naming in `createProperWorktreeStructure`
+- Added comprehensive tests covering all edge cases and error conditions
+- All tests pass and functionality works as expected
 
 ---
 

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -530,8 +530,11 @@ func CreateAdditionalWorktrees(executor git.GitExecutor, targetDir string, branc
 			continue
 		}
 
+		// Generate filesystem-safe directory path for the worktree
+		dirName := git.BranchToDirectoryName(branch)
+		worktreePath := filepath.Join(targetDir, dirName)
+
 		// Check if worktree already exists (e.g., if this was the default branch)
-		worktreePath := filepath.Join(targetDir, branch)
 		if _, err := os.Stat(worktreePath); err == nil {
 			log.Debug("worktree already exists", "branch", branch, "path", worktreePath)
 			continue
@@ -540,7 +543,8 @@ func CreateAdditionalWorktrees(executor git.GitExecutor, targetDir string, branc
 		fmt.Printf("Creating worktree for branch '%s'...\n", branch)
 		log.Debug("creating worktree", "branch", branch, "path", worktreePath)
 
-		_, err := executor.Execute("worktree", "add", worktreePath, branch)
+		// Create worktree with filesystem-safe directory naming
+		_, err := git.CreateWorktreeFromExistingBranch(executor, branch, targetDir)
 		if err != nil {
 			log.Warn("failed to create worktree", "branch", branch, "error", err)
 			fmt.Printf("Warning: failed to create worktree for branch '%s': %v\n", branch, err)

--- a/internal/git/naming.go
+++ b/internal/git/naming.go
@@ -1,0 +1,114 @@
+package git
+
+import (
+	"regexp"
+	"strings"
+)
+
+// BranchToDirectoryName converts a branch name to a filesystem-safe directory name.
+// This function handles common filesystem-unsafe characters by replacing them with safe alternatives.
+//
+// Examples:
+//   - "fix/123" -> "fix-123"
+//   - "feature/user/auth" -> "feature-user-auth"
+//   - "bugfix/issue#456" -> "bugfix-issue-456"
+//   - "hotfix/v1.2.3" -> "hotfix-v1.2.3"
+func BranchToDirectoryName(branchName string) string {
+	if branchName == "" {
+		return ""
+	}
+
+	// Replace filesystem-unsafe characters with safe alternatives
+	dirName := branchName
+
+	// Replace forward slashes with hyphens (most common case)
+	dirName = strings.ReplaceAll(dirName, "/", "-")
+
+	// Replace backslashes with hyphens (Windows compatibility)
+	dirName = strings.ReplaceAll(dirName, "\\", "-")
+
+	// Replace other problematic characters
+	dirName = strings.ReplaceAll(dirName, ":", "-")
+	dirName = strings.ReplaceAll(dirName, "*", "-")
+	dirName = strings.ReplaceAll(dirName, "?", "-")
+	dirName = strings.ReplaceAll(dirName, "\"", "-")
+	dirName = strings.ReplaceAll(dirName, "<", "-")
+	dirName = strings.ReplaceAll(dirName, ">", "-")
+	dirName = strings.ReplaceAll(dirName, "|", "-")
+	dirName = strings.ReplaceAll(dirName, "#", "-")
+
+	// Remove or replace spaces and tabs
+	dirName = strings.ReplaceAll(dirName, " ", "-")
+	dirName = strings.ReplaceAll(dirName, "\t", "-")
+
+	// Replace multiple consecutive hyphens with single hyphen
+	multiHyphen := regexp.MustCompile(`-+`)
+	dirName = multiHyphen.ReplaceAllString(dirName, "-")
+
+	// Remove leading/trailing hyphens
+	dirName = strings.Trim(dirName, "-")
+
+	// Handle edge case where the result might be empty
+	if dirName == "" {
+		return "worktree"
+	}
+
+	return dirName
+}
+
+// IsValidDirectoryName checks if a directory name is filesystem-safe.
+// This function validates that the name doesn't contain problematic characters
+// that could cause issues on various filesystems.
+func IsValidDirectoryName(name string) bool {
+	if name == "" {
+		return false
+	}
+
+	// Check for problematic characters
+	problematicChars := []string{"/", "\\", ":", "*", "?", "\"", "<", ">", "|", "#"}
+	for _, char := range problematicChars {
+		if strings.Contains(name, char) {
+			return false
+		}
+	}
+
+	// Check for leading/trailing spaces or dots (problematic on some filesystems)
+	if strings.HasPrefix(name, " ") || strings.HasSuffix(name, " ") ||
+		strings.HasPrefix(name, ".") || strings.HasSuffix(name, ".") {
+		return false
+	}
+
+	// Check for reserved names on Windows
+	reservedNames := []string{
+		"CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4",
+		"COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5",
+		"LPT6", "LPT7", "LPT8", "LPT9",
+	}
+
+	upperName := strings.ToUpper(name)
+	for _, reserved := range reservedNames {
+		if upperName == reserved {
+			return false
+		}
+	}
+
+	return true
+}
+
+// NormalizeBranchName ensures a branch name is valid for Git operations.
+// This function primarily validates that the branch name follows Git's naming conventions.
+func NormalizeBranchName(branchName string) string {
+	if branchName == "" {
+		return ""
+	}
+
+	// Git branch names cannot start with a hyphen
+	if strings.HasPrefix(branchName, "-") {
+		branchName = "branch" + branchName
+	}
+
+	// Git branch names cannot end with a dot
+	branchName = strings.TrimSuffix(branchName, ".")
+
+	return branchName
+}

--- a/internal/git/naming_test.go
+++ b/internal/git/naming_test.go
@@ -1,0 +1,289 @@
+package git
+
+import (
+	"testing"
+)
+
+func TestBranchToDirectoryName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple branch name",
+			input:    "main",
+			expected: "main",
+		},
+		{
+			name:     "branch with forward slash",
+			input:    "fix/123",
+			expected: "fix-123",
+		},
+		{
+			name:     "branch with multiple slashes",
+			input:    "feature/user/auth",
+			expected: "feature-user-auth",
+		},
+		{
+			name:     "branch with backslash",
+			input:    "fix\\windows",
+			expected: "fix-windows",
+		},
+		{
+			name:     "branch with special characters",
+			input:    "bugfix/issue#456",
+			expected: "bugfix-issue-456",
+		},
+		{
+			name:     "branch with spaces and tabs",
+			input:    "fix bug\twith spaces",
+			expected: "fix-bug-with-spaces",
+		},
+		{
+			name:     "branch with multiple problematic characters",
+			input:    "fix/issue:*?\"<>|#123",
+			expected: "fix-issue-123",
+		},
+		{
+			name:     "branch with multiple consecutive hyphens",
+			input:    "fix//issue",
+			expected: "fix-issue",
+		},
+		{
+			name:     "branch with leading/trailing hyphens",
+			input:    "/fix/issue/",
+			expected: "fix-issue",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only problematic characters",
+			input:    "///",
+			expected: "worktree",
+		},
+		{
+			name:     "version branch",
+			input:    "release/v1.2.3",
+			expected: "release-v1.2.3",
+		},
+		{
+			name:     "branch with underscores (should be preserved)",
+			input:    "feature_branch",
+			expected: "feature_branch",
+		},
+		{
+			name:     "branch with dots (should be preserved)",
+			input:    "hotfix/v1.2.3",
+			expected: "hotfix-v1.2.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BranchToDirectoryName(tt.input)
+			if result != tt.expected {
+				t.Errorf("BranchToDirectoryName(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsValidDirectoryName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "valid simple name",
+			input:    "main",
+			expected: true,
+		},
+		{
+			name:     "valid name with hyphens",
+			input:    "fix-123",
+			expected: true,
+		},
+		{
+			name:     "valid name with underscores",
+			input:    "feature_branch",
+			expected: true,
+		},
+		{
+			name:     "invalid - forward slash",
+			input:    "fix/123",
+			expected: false,
+		},
+		{
+			name:     "invalid - backslash",
+			input:    "fix\\123",
+			expected: false,
+		},
+		{
+			name:     "invalid - colon",
+			input:    "fix:123",
+			expected: false,
+		},
+		{
+			name:     "invalid - asterisk",
+			input:    "fix*123",
+			expected: false,
+		},
+		{
+			name:     "invalid - question mark",
+			input:    "fix?123",
+			expected: false,
+		},
+		{
+			name:     "invalid - double quote",
+			input:    "fix\"123",
+			expected: false,
+		},
+		{
+			name:     "invalid - less than",
+			input:    "fix<123",
+			expected: false,
+		},
+		{
+			name:     "invalid - greater than",
+			input:    "fix>123",
+			expected: false,
+		},
+		{
+			name:     "invalid - pipe",
+			input:    "fix|123",
+			expected: false,
+		},
+		{
+			name:     "invalid - hash",
+			input:    "fix#123",
+			expected: false,
+		},
+		{
+			name:     "invalid - leading space",
+			input:    " fix123",
+			expected: false,
+		},
+		{
+			name:     "invalid - trailing space",
+			input:    "fix123 ",
+			expected: false,
+		},
+		{
+			name:     "invalid - leading dot",
+			input:    ".fix123",
+			expected: false,
+		},
+		{
+			name:     "invalid - trailing dot",
+			input:    "fix123.",
+			expected: false,
+		},
+		{
+			name:     "invalid - empty string",
+			input:    "",
+			expected: false,
+		},
+		{
+			name:     "invalid - Windows reserved name CON",
+			input:    "CON",
+			expected: false,
+		},
+		{
+			name:     "invalid - Windows reserved name PRN",
+			input:    "PRN",
+			expected: false,
+		},
+		{
+			name:     "invalid - Windows reserved name AUX",
+			input:    "AUX",
+			expected: false,
+		},
+		{
+			name:     "invalid - Windows reserved name NUL",
+			input:    "NUL",
+			expected: false,
+		},
+		{
+			name:     "invalid - Windows reserved name COM1",
+			input:    "COM1",
+			expected: false,
+		},
+		{
+			name:     "invalid - Windows reserved name LPT1",
+			input:    "LPT1",
+			expected: false,
+		},
+		{
+			name:     "valid - similar to reserved but different",
+			input:    "CONSOLE",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsValidDirectoryName(tt.input)
+			if result != tt.expected {
+				t.Errorf("IsValidDirectoryName(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeBranchName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "normal branch name",
+			input:    "main",
+			expected: "main",
+		},
+		{
+			name:     "branch name with slash",
+			input:    "fix/123",
+			expected: "fix/123",
+		},
+		{
+			name:     "branch name starting with hyphen",
+			input:    "-fix",
+			expected: "branch-fix",
+		},
+		{
+			name:     "branch name ending with dot",
+			input:    "fix.",
+			expected: "fix",
+		},
+		{
+			name:     "branch name with both issues",
+			input:    "-fix.",
+			expected: "branch-fix",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "valid branch name with special characters",
+			input:    "feature/user_auth",
+			expected: "feature/user_auth",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizeBranchName(tt.input)
+			if result != tt.expected {
+				t.Errorf("NormalizeBranchName(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/git/operations.go
+++ b/internal/git/operations.go
@@ -905,8 +905,9 @@ func createProperWorktreeStructure(executor GitExecutor, dir string) error {
 	// Use the detected default branch as the worktree branch
 	currentBranch := defaultBranch
 
-	// Create worktree directory path
-	worktreePath := filepath.Join(dir, currentBranch)
+	// Create worktree directory path using filesystem-safe naming
+	dirName := BranchToDirectoryName(currentBranch)
+	worktreePath := filepath.Join(dir, dirName)
 
 	// Check if worktree directory already exists
 	if _, err := os.Stat(worktreePath); err == nil {
@@ -960,7 +961,7 @@ func createProperWorktreeStructure(executor GitExecutor, dir string) error {
 		}
 
 		// Create the worktree - this will populate it with the files from the branch
-		_, err = executor.Execute("worktree", "add", worktreePath, currentBranch)
+		_, err = CreateWorktreeFromExistingBranch(executor, currentBranch, dir)
 		if err != nil {
 			return fmt.Errorf("failed to create worktree for branch %s: %w", currentBranch, err)
 		}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -1,0 +1,176 @@
+package git
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// CreateWorktreeWithSafeNaming creates a new worktree with filesystem-safe directory naming
+// while preserving the original branch name for Git operations.
+//
+// This function addresses the issue where branch names like "fix/123" would create
+// problematic directory structures or incorrect branch names when using git worktree add directly.
+//
+// Parameters:
+//   - executor: GitExecutor interface for running git commands
+//   - branchName: The desired branch name (e.g., "fix/123")
+//   - basePath: The base directory where worktrees should be created
+//
+// Returns:
+//   - worktreePath: The full path to the created worktree directory
+//   - error: Any error encountered during worktree creation
+//
+// Example:
+//
+//	path, err := CreateWorktreeWithSafeNaming(executor, "fix/123", "/repo/worktrees")
+//	// Creates directory: /repo/worktrees/fix-123
+//	// Creates branch: fix/123
+func CreateWorktreeWithSafeNaming(executor GitExecutor, branchName, basePath string) (string, error) {
+	if branchName == "" {
+		return "", fmt.Errorf("branch name cannot be empty")
+	}
+
+	if basePath == "" {
+		return "", fmt.Errorf("base path cannot be empty")
+	}
+
+	// Convert branch name to filesystem-safe directory name
+	dirName := BranchToDirectoryName(branchName)
+	if dirName == "" {
+		return "", fmt.Errorf("could not create valid directory name from branch: %s", branchName)
+	}
+
+	// Create the full worktree path
+	worktreePath := filepath.Join(basePath, dirName)
+
+	// Normalize the branch name for Git operations
+	normalizedBranchName := NormalizeBranchName(branchName)
+	if normalizedBranchName == "" {
+		return "", fmt.Errorf("could not create valid branch name from: %s", branchName)
+	}
+
+	// Create the worktree with explicit branch name using -b flag
+	// This ensures the branch name is exactly what we want, not derived from the path
+	_, err := executor.Execute("worktree", "add", "-b", normalizedBranchName, worktreePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create worktree for branch %s at %s: %w", normalizedBranchName, worktreePath, err)
+	}
+
+	return worktreePath, nil
+}
+
+// CreateWorktreeFromExistingBranch creates a worktree from an existing branch with safe naming.
+// Unlike CreateWorktreeWithSafeNaming, this function doesn't create a new branch but checks out
+// an existing one into a filesystem-safe directory.
+//
+// Parameters:
+//   - executor: GitExecutor interface for running git commands
+//   - branchName: The existing branch name to check out
+//   - basePath: The base directory where worktrees should be created
+//
+// Returns:
+//   - worktreePath: The full path to the created worktree directory
+//   - error: Any error encountered during worktree creation
+func CreateWorktreeFromExistingBranch(executor GitExecutor, branchName, basePath string) (string, error) {
+	if branchName == "" {
+		return "", fmt.Errorf("branch name cannot be empty")
+	}
+
+	if basePath == "" {
+		return "", fmt.Errorf("base path cannot be empty")
+	}
+
+	// Convert branch name to filesystem-safe directory name
+	dirName := BranchToDirectoryName(branchName)
+	if dirName == "" {
+		return "", fmt.Errorf("could not create valid directory name from branch: %s", branchName)
+	}
+
+	// Create the full worktree path
+	worktreePath := filepath.Join(basePath, dirName)
+
+	// Create the worktree from existing branch
+	_, err := executor.Execute("worktree", "add", worktreePath, branchName)
+	if err != nil {
+		return "", fmt.Errorf("failed to create worktree from existing branch %s at %s: %w", branchName, worktreePath, err)
+	}
+
+	return worktreePath, nil
+}
+
+// RemoveWorktree removes a worktree directory and its Git worktree registration.
+//
+// Parameters:
+//   - executor: GitExecutor interface for running git commands
+//   - worktreePath: The path to the worktree directory to remove
+//
+// Returns:
+//   - error: Any error encountered during worktree removal
+func RemoveWorktree(executor GitExecutor, worktreePath string) error {
+	if worktreePath == "" {
+		return fmt.Errorf("worktree path cannot be empty")
+	}
+
+	_, err := executor.Execute("worktree", "remove", worktreePath)
+	if err != nil {
+		return fmt.Errorf("failed to remove worktree at %s: %w", worktreePath, err)
+	}
+
+	return nil
+}
+
+// ListWorktrees returns a list of all worktrees in the repository.
+//
+// Parameters:
+//   - executor: GitExecutor interface for running git commands
+//
+// Returns:
+//   - []string: List of worktree paths
+//   - error: Any error encountered during worktree listing
+func ListWorktrees(executor GitExecutor) ([]string, error) {
+	output, err := executor.Execute("worktree", "list", "--porcelain")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list worktrees: %w", err)
+	}
+
+	// Parse the porcelain output to extract worktree paths
+	// The format is: "worktree <path>" for each worktree
+	var worktrees []string
+	lines := splitLines(output)
+
+	for _, line := range lines {
+		if len(line) > 9 && line[:9] == "worktree " {
+			worktreePath := line[9:]
+			worktrees = append(worktrees, worktreePath)
+		}
+	}
+
+	return worktrees, nil
+}
+
+// splitLines splits a string into lines, handling different line endings
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+
+	var lines []string
+	var current string
+
+	for _, char := range s {
+		if char == '\n' {
+			if current != "" {
+				lines = append(lines, current)
+				current = ""
+			}
+		} else if char != '\r' {
+			current += string(char)
+		}
+	}
+
+	if current != "" {
+		lines = append(lines, current)
+	}
+
+	return lines
+}

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -1,0 +1,469 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// MockGitExecutor for testing worktree operations
+type MockGitExecutor struct {
+	commands [][]string
+	outputs  map[string]string
+	errors   map[string]error
+}
+
+func NewMockGitExecutor() *MockGitExecutor {
+	return &MockGitExecutor{
+		commands: make([][]string, 0),
+		outputs:  make(map[string]string),
+		errors:   make(map[string]error),
+	}
+}
+
+func (m *MockGitExecutor) Execute(args ...string) (string, error) {
+	m.commands = append(m.commands, args)
+	key := fmt.Sprintf("%v", args)
+	if err, exists := m.errors[key]; exists {
+		return "", err
+	}
+	if output, exists := m.outputs[key]; exists {
+		return output, nil
+	}
+	return "", nil
+}
+
+func (m *MockGitExecutor) ExecuteWithContext(ctx context.Context, args ...string) (string, error) {
+	return m.Execute(args...)
+}
+
+func (m *MockGitExecutor) SetOutput(args []string, output string) {
+	key := fmt.Sprintf("%v", args)
+	m.outputs[key] = output
+}
+
+func (m *MockGitExecutor) SetError(args []string, err error) {
+	key := fmt.Sprintf("%v", args)
+	m.errors[key] = err
+}
+
+func (m *MockGitExecutor) GetCommands() [][]string {
+	return m.commands
+}
+
+func TestCreateWorktreeWithSafeNaming(t *testing.T) {
+	tests := []struct {
+		name          string
+		branchName    string
+		basePath      string
+		expectedPath  string
+		expectedError string
+		simulateError bool
+	}{
+		{
+			name:         "simple branch name",
+			branchName:   "main",
+			basePath:     "/repo/worktrees",
+			expectedPath: "/repo/worktrees/main",
+		},
+		{
+			name:         "branch with forward slash",
+			branchName:   "fix/123",
+			basePath:     "/repo/worktrees",
+			expectedPath: "/repo/worktrees/fix-123",
+		},
+		{
+			name:         "branch with multiple slashes",
+			branchName:   "feature/user/auth",
+			basePath:     "/repo/worktrees",
+			expectedPath: "/repo/worktrees/feature-user-auth",
+		},
+		{
+			name:         "branch with special characters",
+			branchName:   "bugfix/issue#456",
+			basePath:     "/repo/worktrees",
+			expectedPath: "/repo/worktrees/bugfix-issue-456",
+		},
+		{
+			name:          "empty branch name",
+			branchName:    "",
+			basePath:      "/repo/worktrees",
+			expectedError: "branch name cannot be empty",
+		},
+		{
+			name:          "empty base path",
+			branchName:    "main",
+			basePath:      "",
+			expectedError: "base path cannot be empty",
+		},
+		{
+			name:          "git command fails",
+			branchName:    "main",
+			basePath:      "/repo/worktrees",
+			simulateError: true,
+			expectedError: "failed to create worktree for branch main at /repo/worktrees/main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := NewMockGitExecutor()
+
+			if tt.simulateError {
+				expectedPath := "/repo/worktrees/main"
+				executor.SetError([]string{"worktree", "add", "-b", tt.branchName, expectedPath}, errors.New("git error"))
+			}
+
+			path, err := CreateWorktreeWithSafeNaming(executor, tt.branchName, tt.basePath)
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Errorf("CreateWorktreeWithSafeNaming() error = nil, want error containing %q", tt.expectedError)
+					return
+				}
+				if err.Error() != tt.expectedError && !contains(err.Error(), tt.expectedError) {
+					t.Errorf("CreateWorktreeWithSafeNaming() error = %q, want error containing %q", err.Error(), tt.expectedError)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("CreateWorktreeWithSafeNaming() error = %v, want nil", err)
+				return
+			}
+
+			if path != tt.expectedPath {
+				t.Errorf("CreateWorktreeWithSafeNaming() path = %q, want %q", path, tt.expectedPath)
+			}
+
+			// Verify the correct git command was executed
+			if !tt.simulateError && tt.expectedError == "" {
+				commands := executor.GetCommands()
+				if len(commands) != 1 {
+					t.Errorf("Expected 1 git command, got %d", len(commands))
+					return
+				}
+
+				expectedCmd := []string{"worktree", "add", "-b", tt.branchName, tt.expectedPath}
+				if !slicesEqual(commands[0], expectedCmd) {
+					t.Errorf("Expected git command %v, got %v", expectedCmd, commands[0])
+				}
+			}
+		})
+	}
+}
+
+func TestCreateWorktreeFromExistingBranch(t *testing.T) {
+	tests := []struct {
+		name          string
+		branchName    string
+		basePath      string
+		expectedPath  string
+		expectedError string
+		simulateError bool
+	}{
+		{
+			name:         "simple branch name",
+			branchName:   "main",
+			basePath:     "/repo/worktrees",
+			expectedPath: "/repo/worktrees/main",
+		},
+		{
+			name:         "branch with forward slash",
+			branchName:   "fix/123",
+			basePath:     "/repo/worktrees",
+			expectedPath: "/repo/worktrees/fix-123",
+		},
+		{
+			name:          "empty branch name",
+			branchName:    "",
+			basePath:      "/repo/worktrees",
+			expectedError: "branch name cannot be empty",
+		},
+		{
+			name:          "empty base path",
+			branchName:    "main",
+			basePath:      "",
+			expectedError: "base path cannot be empty",
+		},
+		{
+			name:          "git command fails",
+			branchName:    "main",
+			basePath:      "/repo/worktrees",
+			simulateError: true,
+			expectedError: "failed to create worktree from existing branch main at /repo/worktrees/main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := NewMockGitExecutor()
+
+			if tt.simulateError {
+				expectedPath := "/repo/worktrees/main"
+				executor.SetError([]string{"worktree", "add", expectedPath, tt.branchName}, errors.New("git error"))
+			}
+
+			path, err := CreateWorktreeFromExistingBranch(executor, tt.branchName, tt.basePath)
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Errorf("CreateWorktreeFromExistingBranch() error = nil, want error containing %q", tt.expectedError)
+					return
+				}
+				if !contains(err.Error(), tt.expectedError) {
+					t.Errorf("CreateWorktreeFromExistingBranch() error = %q, want error containing %q", err.Error(), tt.expectedError)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("CreateWorktreeFromExistingBranch() error = %v, want nil", err)
+				return
+			}
+
+			if path != tt.expectedPath {
+				t.Errorf("CreateWorktreeFromExistingBranch() path = %q, want %q", path, tt.expectedPath)
+			}
+
+			// Verify the correct git command was executed
+			if !tt.simulateError && tt.expectedError == "" {
+				commands := executor.GetCommands()
+				if len(commands) != 1 {
+					t.Errorf("Expected 1 git command, got %d", len(commands))
+					return
+				}
+
+				expectedCmd := []string{"worktree", "add", tt.expectedPath, tt.branchName}
+				if !slicesEqual(commands[0], expectedCmd) {
+					t.Errorf("Expected git command %v, got %v", expectedCmd, commands[0])
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveWorktree(t *testing.T) {
+	tests := []struct {
+		name          string
+		worktreePath  string
+		expectedError string
+		simulateError bool
+	}{
+		{
+			name:         "valid worktree path",
+			worktreePath: "/repo/worktrees/feature-branch",
+		},
+		{
+			name:          "empty worktree path",
+			worktreePath:  "",
+			expectedError: "worktree path cannot be empty",
+		},
+		{
+			name:          "git command fails",
+			worktreePath:  "/repo/worktrees/feature-branch",
+			simulateError: true,
+			expectedError: "failed to remove worktree at /repo/worktrees/feature-branch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := NewMockGitExecutor()
+
+			if tt.simulateError {
+				executor.SetError([]string{"worktree", "remove", tt.worktreePath}, errors.New("git error"))
+			}
+
+			err := RemoveWorktree(executor, tt.worktreePath)
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Errorf("RemoveWorktree() error = nil, want error containing %q", tt.expectedError)
+					return
+				}
+				if !contains(err.Error(), tt.expectedError) {
+					t.Errorf("RemoveWorktree() error = %q, want error containing %q", err.Error(), tt.expectedError)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("RemoveWorktree() error = %v, want nil", err)
+				return
+			}
+
+			// Verify the correct git command was executed
+			if !tt.simulateError {
+				commands := executor.GetCommands()
+				if len(commands) != 1 {
+					t.Errorf("Expected 1 git command, got %d", len(commands))
+					return
+				}
+
+				expectedCmd := []string{"worktree", "remove", tt.worktreePath}
+				if !slicesEqual(commands[0], expectedCmd) {
+					t.Errorf("Expected git command %v, got %v", expectedCmd, commands[0])
+				}
+			}
+		})
+	}
+}
+
+func TestListWorktrees(t *testing.T) {
+	tests := []struct {
+		name          string
+		gitOutput     string
+		expectedPaths []string
+		expectedError string
+		simulateError bool
+	}{
+		{
+			name:          "single worktree",
+			gitOutput:     "worktree /repo\n",
+			expectedPaths: []string{"/repo"},
+		},
+		{
+			name: "multiple worktrees",
+			gitOutput: `worktree /repo
+worktree /repo/worktrees/feature-branch
+worktree /repo/worktrees/fix-123
+`,
+			expectedPaths: []string{"/repo", "/repo/worktrees/feature-branch", "/repo/worktrees/fix-123"},
+		},
+		{
+			name:          "empty output",
+			gitOutput:     "",
+			expectedPaths: nil,
+		},
+		{
+			name:          "git command fails",
+			simulateError: true,
+			expectedError: "failed to list worktrees",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := NewMockGitExecutor()
+
+			if tt.simulateError {
+				executor.SetError([]string{"worktree", "list", "--porcelain"}, errors.New("git error"))
+			} else {
+				executor.SetOutput([]string{"worktree", "list", "--porcelain"}, tt.gitOutput)
+			}
+
+			paths, err := ListWorktrees(executor)
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Errorf("ListWorktrees() error = nil, want error containing %q", tt.expectedError)
+					return
+				}
+				if !contains(err.Error(), tt.expectedError) {
+					t.Errorf("ListWorktrees() error = %q, want error containing %q", err.Error(), tt.expectedError)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("ListWorktrees() error = %v, want nil", err)
+				return
+			}
+
+			if len(paths) != len(tt.expectedPaths) {
+				t.Errorf("ListWorktrees() returned %d paths, want %d", len(paths), len(tt.expectedPaths))
+				return
+			}
+
+			for i, path := range paths {
+				if path != tt.expectedPaths[i] {
+					t.Errorf("ListWorktrees() path[%d] = %q, want %q", i, path, tt.expectedPaths[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSplitLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "single line",
+			input:    "line1",
+			expected: []string{"line1"},
+		},
+		{
+			name:     "multiple lines with \\n",
+			input:    "line1\nline2\nline3",
+			expected: []string{"line1", "line2", "line3"},
+		},
+		{
+			name:     "lines with \\r\\n",
+			input:    "line1\r\nline2\r\nline3",
+			expected: []string{"line1", "line2", "line3"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "single newline",
+			input:    "\n",
+			expected: nil,
+		},
+		{
+			name:     "trailing newline",
+			input:    "line1\nline2\n",
+			expected: []string{"line1", "line2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := splitLines(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("splitLines(%q) returned %d lines, want %d", tt.input, len(result), len(tt.expected))
+				return
+			}
+			for i, line := range result {
+				if line != tt.expected[i] {
+					t.Errorf("splitLines(%q) line[%d] = %q, want %q", tt.input, i, line, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+// Helper functions
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || (len(s) > len(substr) &&
+		(s[:len(substr)] == substr || s[len(s)-len(substr):] == substr ||
+			indexOf(s, substr) >= 0)))
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Implements filesystem-safe worktree directory naming to handle branch names with problematic characters like "fix/123".

#### Changes

- Added `BranchToDirectoryName()` function to convert branch names to safe directory names
- Created `CreateWorktreeWithSafeNaming()` and `CreateWorktreeFromExistingBranch()` functions
- Updated `init.go` and `operations.go` to use safe naming in worktree creation
- Added comprehensive tests covering edge cases and error conditions
- Updated IMPROVEMENTS.md to mark milestone as complete

#### Testing

- [x] Tests added/updated
- [x] All tests pass
- [x] Manual testing completed