### PR TITLE
refactor(add): replace #N PR syntax with --pr flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ have your `.env` files.
 - **Best-practice setup** — Uses the `.bare` repo structure automatically
 - **Switch like branches** — `grove switch main` just works
 - **File preservation** — `.env`, `.envrc` copied to new worktrees
-- **PR checkout** — `grove add #123` creates a worktree for any PR
+- **PR checkout** — `grove add --pr 123` creates a worktree for any PR
 - **Post-create hooks** — Run `npm install` automatically after creating worktrees
 
 
@@ -190,7 +190,7 @@ grove init convert --branches develop,staging
 </details>
 
 <details>
-<summary><code>grove add &lt;branch|#PR|ref&gt;</code></summary>
+<summary><code>grove add [branch|PR-URL|ref]</code></summary>
 
 Add a worktree for a branch, pull request, or ref.
 
@@ -200,6 +200,7 @@ Add a worktree for a branch, pull request, or ref.
 - `--base <branch>` — Create new branch from base instead of HEAD
 - `--name <name>` — Custom directory name
 - `-d, --detach` — Detached HEAD state
+- `--pr <number>` — Create worktree for a pull request
 
 **Examples:**
 
@@ -207,8 +208,8 @@ Add a worktree for a branch, pull request, or ref.
 grove add feat/auth
 grove add feat/auth --switch
 grove add --base main feat/auth
-grove add                 #123                    # PR by number
-grove add --detach v1.0.0 # Tag in detached HEAD
+grove add --pr 123            # PR by number
+grove add --detach v1.0.0     # Tag in detached HEAD
 ```
 
 </details>

--- a/cmd/grove/testdata/script/add_pr_integration.txt
+++ b/cmd/grove/testdata/script/add_pr_integration.txt
@@ -24,7 +24,7 @@ exec git config commit.gpgsign false
 ## PR number creates worktree (using test PR #7)
 # Note: PR worktrees are named pr-<number> to avoid conflicts with branch worktrees
 
-exec grove add '#7'
+exec grove add --pr 7
 stdout 'Created worktree for PR #7'
 stdout 'pr-7'
 exists ../pr-7
@@ -41,18 +41,18 @@ exists ../pr-7
 
 ## PR doesn't exist → error
 
-! exec grove add '#99999'
+! exec grove add --pr 99999
 stderr 'not found'
 
 ## PR branch already has worktree → error
 
-! exec grove add '#7'
+! exec grove add --pr 7
 stderr 'worktree already exists'
 
 ## PR with --switch outputs only path
 
 exec grove remove pr-7
-exec grove add --switch '#7'
+exec grove add --switch --pr 7
 stdout '^.*/pr-7$'
 ! stdout 'Created worktree'
 exists ../pr-7
@@ -76,6 +76,6 @@ cd no-gh-workspace/main
 exec git config user.name "Test"
 exec git config user.email "test@example.com"
 # PR number requires GitHub origin
-! exec grove add '#123'
+! exec grove add --pr 123
 stderr 'requires workspace context'
 

--- a/cmd/grove/testdata/script/add_validation.txt
+++ b/cmd/grove/testdata/script/add_validation.txt
@@ -6,33 +6,46 @@
 exec grove add --help
 stdout 'Create a worktree from a branch'
 stdout 'Usage:'
-stdout '<branch|#PR|PR-URL|ref>'
+stdout '\[branch|PR-URL|ref\]'
 stdout '--base'
 stdout '--detach'
 stdout '--name'
 stdout '--switch'
+stdout '--pr'
 ! stderr .
 
 ## Argument validation
 
-# No arguments
+# No arguments and no --pr flag
 ! exec grove add
-stderr '^✗ accepts 1 arg'
-stderr 'received 0'
+stderr '^✗ requires branch, PR URL, or --pr flag'
 
 # Too many arguments
 ! exec grove add branch extra
-stderr '^✗ accepts 1 arg'
+stderr '^✗ accepts at most 1 arg'
 stderr 'received 2'
+
+# Old #N syntax gives helpful error
+! exec grove add '#123'
+stderr 'syntax no longer supported'
+stderr 'grove add --pr 123'
+
+# --pr cannot be combined with positional argument
+! exec grove add --pr 123 feature
+stderr '^✗ --pr flag cannot be combined with positional argument'
+
+# Negative --pr gives clear error
+! exec grove add --pr -5
+stderr '^✗ --pr must be a positive number'
 
 ## Flag conflicts
 
-# --base with PR reference
-! exec grove add --base main '#123'
+# --base with --pr
+! exec grove add --base main --pr 123
 stderr '^✗ --base cannot be used with PR references'
 
-# --detach with PR reference
-! exec grove add --detach '#123'
+# --detach with --pr
+! exec grove add --detach --pr 123
 stderr '^✗ --detach cannot be used with PR references'
 
 # --detach and --base together


### PR DESCRIPTION
Replace `grove add #123` syntax with `grove add --pr 123` flag.

The `#N` syntax was problematic because shells interpret `#` as a comment character, requiring users to quote it (`grove add '#123'`). The `--pr` flag is explicit and doesn't require shell escaping.

#### Changes

- Replaced `grove add #123` with `grove add --pr 123` flag
- Added helpful error message when users try old `#N` syntax
- Added validation for negative PR numbers (`--pr -5` now errors clearly)
- Updated README documentation to reflect new syntax

#### Test plan

- [ ] `grove add --pr 7` creates worktree for PR #7
- [ ] `grove add '#123'` shows: `'#123' syntax no longer supported, use: grove add --pr 123`
- [ ] `grove add --pr -5` shows: `--pr must be a positive number`
- [ ] `grove add --pr 123 feature` shows: `--pr flag cannot be combined with positional argument`