### PR TITLE
ci: skip code jobs when only non-code files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
               - 'go.mod'
               - 'go.sum'
               - '.golangci.yml'
+              - '.github/workflows/ci.yml'
 
   lint:
     needs: changes


### PR DESCRIPTION
Adds path filtering to skip lint, test, and build jobs when PRs only modify non-code files (docs, configs, etc.). Saves CI minutes on documentation-only changes.

#### Changes

- Added `changes` job using `dorny/paths-filter@v3` to detect Go-related file changes
- Made `lint`, `test-unit`, `test-integration`, and `build` jobs conditional on code changes
- Jobs still run unconditionally on pushes to main (safety net for merges)

#### Test plan

- [ ] Create a PR that only modifies `.md` files — lint/test/build jobs should be skipped
- [ ] Create a PR that modifies `.go` files — all jobs should run
- [ ] Verify pushes to main still run all jobs regardless of file types