### PR TITLE
fix(#36): make go install command lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ curl -fsSL https://raw.githubusercontent.com/sQVe/grove/main/install.sh | sh
 ### Go install
 
 ```bash
-go install github.com/sQVe/grove/cmd/grove@latest
+go install github.com/sqve/grove/cmd/grove@latest
 ```
 
 ### From source


### PR DESCRIPTION
<!--
Thanks for contributing to Grove!

Before submitting:
- Link related issues with "Fixes #123" or "Related to #123"
- Keep changes focused on a single concern
- Add tests for new functionality
-->

Changed the command specified in the Readme.

#### Changes

- Changed the command specified in the Readme.

#### Test plan

- Tried the installation command

---

Fixes #36 

