### PR TITLE
fix(prune): detect multi-commit squash merges via GitHub API

### DIFF
--- a/.changes/unreleased/fixed-gh-squash-detection.yaml
+++ b/.changes/unreleased/fixed-gh-squash-detection.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: Detect multi-commit squash merges via GitHub CLI when pruning

--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ sudo mv grove /usr/local/bin/
 
 Download `.deb` or `.rpm` packages from [GitHub Releases](https://github.com/sQVe/grove/releases/latest).
 
+### Optional: GitHub CLI
+
+Grove works without additional dependencies, but installing the [GitHub CLI](https://cli.github.com/) (`gh`) enables enhanced features:
+
+- **PR worktrees**: Create worktrees from pull requests with `grove add --pr 123` or `grove clone https://github.com/owner/repo/pull/123`
+- **Squash-merge detection**: `grove prune` accurately detects branches merged via GitHub's squash-and-merge, even with multiple commits. Without `gh`, only single-commit squash merges are detected via git.
+
+See [GitHub CLI installation](https://github.com/cli/cli#installation) for setup instructions.
+
 ## 🔧 Setup
 
 ### Shell Integration (Required)


### PR DESCRIPTION
Adds optional GitHub CLI integration to detect multi-commit squash merges during prune.

`git cherry` compares patch-IDs, which fails for multi-commit squash merges because the combined diff has a different patch-ID than individual commits. This adds `gh pr list --state merged` as a fallback.

#### Changes

- Add `GetMergedPRBranches()` to fetch merged PR branch names via GitHub API
- Integrate as fallback in prune's branch deletion logic (after git-native detection)
- Document optional `gh` dependency in README (also enables PR worktrees)
- Single API call with 200 PR limit, O(1) lookup per branch

#### Test plan

- [ ] Run `grove prune` without `gh` installed - should work (git-only detection)
- [ ] Run `grove prune` with `gh` installed but not authenticated - should fall back gracefully
- [ ] Run `grove prune` on repo with multi-commit squash-merged branches - should detect and delete
- [ ] Verify `make ci` passes

Related to #40