### PR TITLE
fix(renovate): use built-in gomodTidy instead of postUpgradeTasks

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,7 @@
   ignoreUnstable: true,
   dependencyDashboard: true,
   labels: ["dependencies"],
+  postUpdateOptions: ["gomodTidy"],
   vulnerabilityAlerts: {
     enabled: true,
     labels: ["security"],
@@ -21,14 +22,6 @@
     automerge: true,
   },
   packageRules: [
-    {
-      matchManagers: ["gomod"],
-      postUpgradeTasks: {
-        commands: ["go mod tidy"],
-        fileFilters: ["go.mod", "go.sum"],
-        executionMode: "branch",
-      },
-    },
     {
       matchManagers: ["github-actions"],
       groupName: "github-actions",


### PR DESCRIPTION
## Summary

- Replace custom `postUpgradeTasks` with Renovate's built-in `postUpdateOptions: ["gomodTidy"]`
- Fixes artifact update failures seen in PR #47 (`renovate/artifacts — Artifact file update failure`)

## Context

The `postUpgradeTasks` approach was failing because Renovate's execution environment may not have Go properly configured. The built-in `gomodTidy` option is designed to work reliably in Renovate's hosted environment.

## Test plan

- [ ] Merge this PR
- [ ] Check the rebase/retry checkbox on PR #47 (or wait for next Renovate run)
- [ ] Verify `renovate/artifacts` status turns green