### PR TITLE
feat: use relative paths for portable worktrees

### DIFF
--- a/.changes/unreleased/added-relativepaths.yaml
+++ b/.changes/unreleased/added-relativepaths.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Use relative paths for portable worktrees (requires Git 2.48+)
+time: 2026-01-15T16:00:00Z

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -9,10 +9,11 @@ changeFormat: '- {{.Body}}{{if .Custom.Issue}} ([#{{.Custom.Issue}}](https://git
 fragmentFileFormat: '{{.Kind | lower}}-{{.Custom.Issue}}{{if not .Custom.Issue}}{{randAlphaNum 8}}{{end}}'
 
 body:
-  type: string
-  useEditor: true
+  block: true
 
 kinds:
+  - label: Breaking
+    auto: major
   - label: Added
     auto: minor
   - label: Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thanks for contributing! Grove makes Git worktrees simple, and we want contribut
 | **Install** | `go mod download && make deps-tools`                  |
 | **Verify**  | `make test-unit && make lint && make build-dev`       |
 
-**Prerequisites:** Go 1.24+, Git 2.5+, golangci-lint
+**Prerequisites:** Go 1.24+, Git 2.48+, golangci-lint
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ The catch: `git worktree` is clunky. Grove makes it feel like `git checkout` —
 
 </details>
 
+## 📋 Requirements
+
+- **Git 2.48+** — Grove uses `--relative-paths` for portable worktrees
+
 ## 📦 Installation
 
 ### Quick install (Linux/macOS)

--- a/cmd/grove/commands/doctor.go
+++ b/cmd/grove/commands/doctor.go
@@ -263,7 +263,12 @@ func detectStaleWorktreeEntries(bareDir string, result *DoctorResult) {
 		// Check if the worktree directory exists
 		// Note: gitdir file contains path to .git FILE (e.g., /path/worktree/.git)
 		// We need to check the parent directory (the actual worktree)
+		// The path may be relative (e.g., ../../main/.git) or absolute
 		gitFilePath := strings.TrimSpace(string(content))
+		if !filepath.IsAbs(gitFilePath) {
+			// Resolve relative path from the gitdir file's directory
+			gitFilePath = filepath.Clean(filepath.Join(worktreesDir, worktreeName, gitFilePath))
+		}
 		worktreeDir := filepath.Dir(gitFilePath)
 		if _, err := os.Stat(worktreeDir); os.IsNotExist(err) {
 			result.Issues = append(result.Issues, Issue{

--- a/cmd/grove/testdata/script/doctor_integration.txt
+++ b/cmd/grove/testdata/script/doctor_integration.txt
@@ -49,6 +49,18 @@ stdout 'orphan-branch'
 # Clean up orphan entry for remaining tests
 exec rm -rf ../.bare/worktrees/orphan-branch
 
+## Detect stale worktree entry with relative path
+
+mkdir ../.bare/worktrees/orphan-relative
+exec sh -c 'echo "../../nonexistent-worktree/.git" > ../.bare/worktrees/orphan-relative/gitdir'
+
+! exec grove doctor
+stdout 'Git Issues'
+stdout '✗ Stale worktree entry'
+stdout 'orphan-relative'
+
+exec rm -rf ../.bare/worktrees/orphan-relative
+
 ## Detect invalid TOML syntax
 
 exec sh -c 'echo "this is not valid toml [[[" > ../.grove.toml'

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -41,8 +41,8 @@ func CreateWorktree(bareRepo, worktreePath, branch string, quiet bool) error {
 		return errors.New("branch name cannot be empty")
 	}
 
-	logger.Debug("Executing: git worktree add %s %s", worktreePath, branch)
-	cmd, cancel := GitCommand("git", "worktree", "add", worktreePath, branch)
+	logger.Debug("Executing: git worktree add --relative-paths %s %s", worktreePath, branch)
+	cmd, cancel := GitCommand("git", "worktree", "add", "--relative-paths", worktreePath, branch)
 	defer cancel()
 	cmd.Dir = bareRepo
 
@@ -62,8 +62,8 @@ func CreateWorktreeWithNewBranch(bareRepo, worktreePath, branch string, quiet bo
 		return errors.New("branch name cannot be empty")
 	}
 
-	logger.Debug("Executing: git worktree add -b %s %s", branch, worktreePath)
-	cmd, cancel := GitCommand("git", "worktree", "add", "-b", branch, worktreePath)
+	logger.Debug("Executing: git worktree add --relative-paths -b %s %s", branch, worktreePath)
+	cmd, cancel := GitCommand("git", "worktree", "add", "--relative-paths", "-b", branch, worktreePath)
 	defer cancel()
 	cmd.Dir = bareRepo
 
@@ -86,8 +86,8 @@ func CreateWorktreeWithNewBranchFrom(bareRepo, worktreePath, branch, base string
 		return errors.New("base reference cannot be empty")
 	}
 
-	logger.Debug("Executing: git worktree add -b %s %s %s", branch, worktreePath, base)
-	cmd, cancel := GitCommand("git", "worktree", "add", "-b", branch, worktreePath, base)
+	logger.Debug("Executing: git worktree add --relative-paths -b %s %s %s", branch, worktreePath, base)
+	cmd, cancel := GitCommand("git", "worktree", "add", "--relative-paths", "-b", branch, worktreePath, base)
 	defer cancel()
 	cmd.Dir = bareRepo
 
@@ -107,8 +107,8 @@ func CreateWorktreeDetached(bareRepo, worktreePath, ref string, quiet bool) erro
 		return errors.New("ref cannot be empty")
 	}
 
-	logger.Debug("Executing: git worktree add --detach %s %s", worktreePath, ref)
-	cmd, cancel := GitCommand("git", "worktree", "add", "--detach", worktreePath, ref)
+	logger.Debug("Executing: git worktree add --relative-paths --detach %s %s", worktreePath, ref)
+	cmd, cancel := GitCommand("git", "worktree", "add", "--relative-paths", "--detach", worktreePath, ref)
 	defer cancel()
 	cmd.Dir = bareRepo
 


### PR DESCRIPTION
Worktrees now use Git's `--relative-paths` flag, making repositories portable across different mount points. Fixes compatibility with devcontainers and allows moving repositories without breaking worktree links.

#### Changes

- Add `--relative-paths` flag to all worktree creation functions
- Update `grove doctor` to resolve relative paths when detecting stale entries
- Bump Git requirement to 2.48+ (when `--relative-paths` was introduced)
- Document Git version requirement in README and CONTRIBUTING.md
- Fix `.changie.yaml` schema (invalid `body` fields) and add `Breaking` kind

#### Test plan

- [x] Run `make test-unit` — 879 tests pass
- [x] Run `make lint` — 0 issues
- [x] Create a worktree and verify `.git` file contains relative path
- [x] Move workspace to different directory and confirm worktrees still work
- [x] Run `grove doctor` on workspace with relative-path worktrees

---

Fixes #49