### PR TITLE
Release v1.3.0

### DIFF
--- a/.changes/unreleased/added-relativepaths.yaml
+++ b/.changes/unreleased/added-relativepaths.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: Use relative paths for portable worktrees (requires Git 2.48+)
-time: 2026-01-15T16:00:00Z

--- a/.changes/v1.3.0.md
+++ b/.changes/v1.3.0.md
@@ -1,0 +1,4 @@
+## [v1.3.0](https://github.com/sQVe/grove/releases/tag/v1.3.0) - 2026-01-15
+
+### Added
+- Use relative paths for portable worktrees (requires Git 2.48+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [v1.3.0](https://github.com/sQVe/grove/releases/tag/v1.3.0) - 2026-01-15
+
+### Added
+- Use relative paths for portable worktrees (requires Git 2.48+)
+
 ## [v1.2.1](https://github.com/sQVe/grove/releases/tag/v1.2.1) - 2026-01-15
 
 ### Fixed


### PR DESCRIPTION
This PR was created by the [Changie release GitHub action](https://github.com/labd/changie-release-action). When you're ready to do a release, you can merge this and the tag v1.3.0 will be created.  If you're not ready to do a release yet, that's fine, whenever you add more changes to main, this PR will be updated.

# Releases
## [v1.3.0](https://github.com/sQVe/grove/releases/tag/v1.3.0) - 2026-01-15

### Added
- Use relative paths for portable worktrees (requires Git 2.48+)