### PR TITLE
Release v1.4.0

### DIFF
--- a/.changes/unreleased/added-auto-refspec.yaml
+++ b/.changes/unreleased/added-auto-refspec.yaml
@@ -1,2 +1,0 @@
-kind: Added
-body: Configure fetch refspec automatically during clone to enable remote branch tracking

--- a/.changes/unreleased/added-doctor-deps.yaml
+++ b/.changes/unreleased/added-doctor-deps.yaml
@@ -1,2 +1,0 @@
-kind: Added
-body: '`grove doctor` checks Git and gh versions with upgrade guidance'

--- a/.changes/unreleased/added-from-flag.yaml
+++ b/.changes/unreleased/added-from-flag.yaml
@@ -1,2 +1,0 @@
-kind: Added
-body: Add `--from` flag to `grove add` for specifying source worktree during file preservation

--- a/.changes/unreleased/added-git-hint.yaml
+++ b/.changes/unreleased/added-git-hint.yaml
@@ -1,2 +1,0 @@
-kind: Added
-body: Detect old Git versions and hint users to run `grove doctor`

--- a/.changes/unreleased/fixed-upstream-tracking.yaml
+++ b/.changes/unreleased/fixed-upstream-tracking.yaml
@@ -1,2 +1,0 @@
-kind: Fixed
-body: Configure upstream tracking automatically when creating worktrees for existing remote branches

--- a/.changes/v1.4.0.md
+++ b/.changes/v1.4.0.md
@@ -1,0 +1,10 @@
+## [v1.4.0](https://github.com/sQVe/grove/releases/tag/v1.4.0) - 2026-01-19
+
+### Added
+- Configure fetch refspec automatically during clone to enable remote branch tracking
+- `grove doctor` checks Git and gh versions with upgrade guidance
+- Add `--from` flag to `grove add` for specifying source worktree during file preservation
+- Detect old Git versions and hint users to run `grove doctor`
+
+### Fixed
+- Configure upstream tracking automatically when creating worktrees for existing remote branches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [v1.4.0](https://github.com/sQVe/grove/releases/tag/v1.4.0) - 2026-01-19
+
+### Added
+- Configure fetch refspec automatically during clone to enable remote branch tracking
+- `grove doctor` checks Git and gh versions with upgrade guidance
+- Add `--from` flag to `grove add` for specifying source worktree during file preservation
+- Detect old Git versions and hint users to run `grove doctor`
+
+### Fixed
+- Configure upstream tracking automatically when creating worktrees for existing remote branches
+
 ## [v1.3.0](https://github.com/sQVe/grove/releases/tag/v1.3.0) - 2026-01-15
 
 ### Added


### PR DESCRIPTION
This PR was created by the [Changie release GitHub action](https://github.com/labd/changie-release-action). When you're ready to do a release, you can merge this and the tag v1.4.0 will be created.  If you're not ready to do a release yet, that's fine, whenever you add more changes to main, this PR will be updated.

# Releases
## [v1.4.0](https://github.com/sQVe/grove/releases/tag/v1.4.0) - 2026-01-19

### Added
- Configure fetch refspec automatically during clone to enable remote branch tracking
- `grove doctor` checks Git and gh versions with upgrade guidance
- Add `--from` flag to `grove add` for specifying source worktree during file preservation
- Detect old Git versions and hint users to run `grove doctor`

### Fixed
- Configure upstream tracking automatically when creating worktrees for existing remote branches