### PR TITLE
Release v1.5.0

### DIFF
--- a/.changes/unreleased/added-61.yaml
+++ b/.changes/unreleased/added-61.yaml
@@ -1,4 +1,0 @@
-kind: Added
-body: '`--json` and `--verbose` flags to `grove fetch` for structured output and commit hash details'
-custom:
-  Issue: 61

--- a/.changes/unreleased/added-71.yaml
+++ b/.changes/unreleased/added-71.yaml
@@ -1,4 +1,0 @@
-kind: Added
-body: '`grove fetch` command to sync all remotes and display new, updated, and pruned refs'
-custom:
-  Issue: 71

--- a/.changes/unreleased/added-73.yaml
+++ b/.changes/unreleased/added-73.yaml
@@ -1,4 +1,0 @@
-kind: Added
-body: Spinner API with `Update`, `StopWithSuccess`, `StopWithError` methods and `StepFormat` helper for step/total formatting
-custom:
-  Issue: 73

--- a/.changes/unreleased/added-doctor-remote.yaml
+++ b/.changes/unreleased/added-doctor-remote.yaml
@@ -1,2 +1,0 @@
-kind: Added
-body: '`grove doctor` checks remote accessibility and warns about unreachable remotes'

--- a/.changes/unreleased/added-error-hints.yaml
+++ b/.changes/unreleased/added-error-hints.yaml
@@ -1,2 +1,0 @@
-kind: Added
-body: Actionable hints to error messages showing recovery commands

--- a/.changes/unreleased/added-hook-streaming.yaml
+++ b/.changes/unreleased/added-hook-streaming.yaml
@@ -1,2 +1,0 @@
-kind: Added
-body: Real-time hook output streaming during `grove add` with prefixed lines identifying each hook

--- a/.changes/unreleased/changed-73.yaml
+++ b/.changes/unreleased/changed-73.yaml
@@ -1,4 +1,0 @@
-kind: Changed
-body: '`grove remove` shows summary counts instead of per-item messages'
-custom:
-  Issue: 73

--- a/.changes/unreleased/changed-output-consistency.yaml
+++ b/.changes/unreleased/changed-output-consistency.yaml
@@ -1,2 +1,0 @@
-kind: Changed
-body: Add spinners to show progress during network operations and improve output consistency across commands

--- a/.changes/v1.5.0.md
+++ b/.changes/v1.5.0.md
@@ -1,0 +1,13 @@
+## [v1.5.0](https://github.com/sQVe/grove/releases/tag/v1.5.0) - 2026-01-27
+
+### Added
+- `--json` and `--verbose` flags to `grove fetch` for structured output and commit hash details ([#61](https://github.com/sQVe/grove/issues/61))
+- `grove fetch` command to sync all remotes and display new, updated, and pruned refs ([#71](https://github.com/sQVe/grove/issues/71))
+- Spinner API with `Update`, `StopWithSuccess`, `StopWithError` methods and `StepFormat` helper for step/total formatting ([#73](https://github.com/sQVe/grove/issues/73))
+- `grove doctor` checks remote accessibility and warns about unreachable remotes
+- Actionable hints to error messages showing recovery commands
+- Real-time hook output streaming during `grove add` with prefixed lines identifying each hook
+
+### Changed
+- `grove remove` shows summary counts instead of per-item messages ([#73](https://github.com/sQVe/grove/issues/73))
+- Add spinners to show progress during network operations and improve output consistency across commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [v1.5.0](https://github.com/sQVe/grove/releases/tag/v1.5.0) - 2026-01-27
+
+### Added
+- `--json` and `--verbose` flags to `grove fetch` for structured output and commit hash details ([#61](https://github.com/sQVe/grove/issues/61))
+- `grove fetch` command to sync all remotes and display new, updated, and pruned refs ([#71](https://github.com/sQVe/grove/issues/71))
+- Spinner API with `Update`, `StopWithSuccess`, `StopWithError` methods and `StepFormat` helper for step/total formatting ([#73](https://github.com/sQVe/grove/issues/73))
+- `grove doctor` checks remote accessibility and warns about unreachable remotes
+- Actionable hints to error messages showing recovery commands
+- Real-time hook output streaming during `grove add` with prefixed lines identifying each hook
+
+### Changed
+- `grove remove` shows summary counts instead of per-item messages ([#73](https://github.com/sQVe/grove/issues/73))
+- Add spinners to show progress during network operations and improve output consistency across commands
+
 ## [v1.4.0](https://github.com/sQVe/grove/releases/tag/v1.4.0) - 2026-01-19
 
 ### Added


### PR DESCRIPTION
This PR was created by the [Changie release GitHub action](https://github.com/labd/changie-release-action). When you're ready to do a release, you can merge this and the tag v1.5.0 will be created.  If you're not ready to do a release yet, that's fine, whenever you add more changes to main, this PR will be updated.

# Releases
## [v1.5.0](https://github.com/sQVe/grove/releases/tag/v1.5.0) - 2026-01-27

### Added
- `--json` and `--verbose` flags to `grove fetch` for structured output and commit hash details ([#61](https://github.com/sQVe/grove/issues/61))
- `grove fetch` command to sync all remotes and display new, updated, and pruned refs ([#71](https://github.com/sQVe/grove/issues/71))
- Spinner API with `Update`, `StopWithSuccess`, `StopWithError` methods and `StepFormat` helper for step/total formatting ([#73](https://github.com/sQVe/grove/issues/73))
- `grove doctor` checks remote accessibility and warns about unreachable remotes
- Actionable hints to error messages showing recovery commands
- Real-time hook output streaming during `grove add` with prefixed lines identifying each hook

### Changed
- `grove remove` shows summary counts instead of per-item messages ([#73](https://github.com/sQVe/grove/issues/73))
- Add spinners to show progress during network operations and improve output consistency across commands