### PR TITLE
Release v1.6.0

### DIFF
--- a/.changes/unreleased/added-79.yaml
+++ b/.changes/unreleased/added-79.yaml
@@ -1,4 +1,0 @@
-kind: Added
-body: Fallback worktree selection by directory name when branch doesn't match, enabling file preservation when primary worktree is on a feature branch
-custom:
-  Issue: 79

--- a/.changes/unreleased/added-81.yaml
+++ b/.changes/unreleased/added-81.yaml
@@ -1,4 +1,0 @@
-kind: Added
-body: Show worktree directory alongside branch name in prune output for easier identification
-custom:
-  Issue: 81

--- a/.changes/v1.6.0.md
+++ b/.changes/v1.6.0.md
@@ -1,0 +1,5 @@
+## [v1.6.0](https://github.com/sQVe/grove/releases/tag/v1.6.0) - 2026-02-03
+
+### Added
+- Fallback worktree selection by directory name when branch doesn't match, enabling file preservation when primary worktree is on a feature branch ([#79](https://github.com/sQVe/grove/issues/79))
+- Show worktree directory alongside branch name in prune output for easier identification ([#81](https://github.com/sQVe/grove/issues/81))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v1.6.0](https://github.com/sQVe/grove/releases/tag/v1.6.0) - 2026-02-03
+
+### Added
+- Fallback worktree selection by directory name when branch doesn't match, enabling file preservation when primary worktree is on a feature branch ([#79](https://github.com/sQVe/grove/issues/79))
+- Show worktree directory alongside branch name in prune output for easier identification ([#81](https://github.com/sQVe/grove/issues/81))
+
 ## [v1.5.0](https://github.com/sQVe/grove/releases/tag/v1.5.0) - 2026-01-27
 
 ### Added


### PR DESCRIPTION
This PR was created by the [Changie release GitHub action](https://github.com/labd/changie-release-action). When you're ready to do a release, you can merge this and the tag v1.6.0 will be created.  If you're not ready to do a release yet, that's fine, whenever you add more changes to main, this PR will be updated.

# Releases
## [v1.6.0](https://github.com/sQVe/grove/releases/tag/v1.6.0) - 2026-02-03

### Added
- Fallback worktree selection by directory name when branch doesn't match, enabling file preservation when primary worktree is on a feature branch ([#79](https://github.com/sQVe/grove/issues/79))
- Show worktree directory alongside branch name in prune output for easier identification ([#81](https://github.com/sQVe/grove/issues/81))