### PR TITLE
Release v1.8.1

### DIFF
--- a/.changes/unreleased/fixed-91.yaml
+++ b/.changes/unreleased/fixed-91.yaml
@@ -1,4 +1,0 @@
-kind: Fixed
-body: Show preserve, link, and hook output when using `grove add --switch`
-custom:
-  Issue: 91

--- a/.changes/unreleased/fixed-link-config-from-main.yaml
+++ b/.changes/unreleased/fixed-link-config-from-main.yaml
@@ -1,2 +1,0 @@
-kind: Fixed
-body: Apply `[link]` and `[preserve]` patterns when `grove add` runs outside the main worktree, by loading `.grove.toml` from any worktree containing it (preferring the default branch)

--- a/.changes/unreleased/fixed-link-conflict-warning.yaml
+++ b/.changes/unreleased/fixed-link-conflict-warning.yaml
@@ -1,2 +1,0 @@
-kind: Fixed
-body: Warn when a `[link]` target conflicts with git-tracked content in the destination worktree instead of silently skipping

--- a/.changes/v1.8.1.md
+++ b/.changes/v1.8.1.md
@@ -1,0 +1,6 @@
+## [v1.8.1](https://github.com/sQVe/grove/releases/tag/v1.8.1) - 2026-04-13
+
+### Fixed
+- Show preserve, link, and hook output when using `grove add --switch` ([#91](https://github.com/sQVe/grove/issues/91))
+- Apply `[link]` and `[preserve]` patterns when `grove add` runs outside the main worktree, by loading `.grove.toml` from any worktree containing it (preferring the default branch)
+- Warn when a `[link]` target conflicts with git-tracked content in the destination worktree instead of silently skipping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [v1.8.1](https://github.com/sQVe/grove/releases/tag/v1.8.1) - 2026-04-13
+
+### Fixed
+- Show preserve, link, and hook output when using `grove add --switch` ([#91](https://github.com/sQVe/grove/issues/91))
+- Apply `[link]` and `[preserve]` patterns when `grove add` runs outside the main worktree, by loading `.grove.toml` from any worktree containing it (preferring the default branch)
+- Warn when a `[link]` target conflicts with git-tracked content in the destination worktree instead of silently skipping
+
 ## [v1.8.0](https://github.com/sQVe/grove/releases/tag/v1.8.0) - 2026-03-04
 
 ### Added


### PR DESCRIPTION
This PR was created by the [Changie release GitHub action](https://github.com/labd/changie-release-action). When you're ready to do a release, you can merge this and the tag v1.8.1 will be created.  If you're not ready to do a release yet, that's fine, whenever you add more changes to main, this PR will be updated.

# Releases
## [v1.8.1](https://github.com/sQVe/grove/releases/tag/v1.8.1) - 2026-04-13

### Fixed
- Show preserve, link, and hook output when using `grove add --switch` ([#91](https://github.com/sQVe/grove/issues/91))
- Apply `[link]` and `[preserve]` patterns when `grove add` runs outside the main worktree, by loading `.grove.toml` from any worktree containing it (preferring the default branch)
- Warn when a `[link]` target conflicts with git-tracked content in the destination worktree instead of silently skipping