### PR TITLE
Release v1.8.2

### DIFF
--- a/.changes/unreleased/fixed-prune-dangling-bare-head.yaml
+++ b/.changes/unreleased/fixed-prune-dangling-bare-head.yaml
@@ -1,2 +1,0 @@
-kind: Fixed
-body: Prune now re-points the bare repo's HEAD when it would otherwise dangle on a deleted branch, keeping subsequent `grove add` invocations working.

--- a/.changes/unreleased/fixed-prune-prunable-worktrees.yaml
+++ b/.changes/unreleased/fixed-prune-prunable-worktrees.yaml
@@ -1,2 +1,0 @@
-kind: Fixed
-body: '`grove prune` now reaps git-prunable (path-gone) worktrees by default instead of skipping them with a "may be corrupted" warning. Live and locked worktrees are left untouched.'

--- a/.changes/v1.8.2.md
+++ b/.changes/v1.8.2.md
@@ -1,0 +1,5 @@
+## [v1.8.2](https://github.com/sQVe/grove/releases/tag/v1.8.2) - 2026-07-01
+
+### Fixed
+- Prune now re-points the bare repo's HEAD when it would otherwise dangle on a deleted branch, keeping subsequent `grove add` invocations working.
+- `grove prune` now reaps git-prunable (path-gone) worktrees by default instead of skipping them with a "may be corrupted" warning. Live and locked worktrees are left untouched.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v1.8.2](https://github.com/sQVe/grove/releases/tag/v1.8.2) - 2026-07-01
+
+### Fixed
+- Prune now re-points the bare repo's HEAD when it would otherwise dangle on a deleted branch, keeping subsequent `grove add` invocations working.
+- `grove prune` now reaps git-prunable (path-gone) worktrees by default instead of skipping them with a "may be corrupted" warning. Live and locked worktrees are left untouched.
+
 ## [v1.8.1](https://github.com/sQVe/grove/releases/tag/v1.8.1) - 2026-04-13
 
 ### Fixed


### PR DESCRIPTION
This PR was created by the [Changie release GitHub action](https://github.com/labd/changie-release-action). When you're ready to do a release, you can merge this and the tag v1.8.2 will be created.  If you're not ready to do a release yet, that's fine, whenever you add more changes to main, this PR will be updated.

# Releases
## [v1.8.2](https://github.com/sQVe/grove/releases/tag/v1.8.2) - 2026-07-01

### Fixed
- Prune now re-points the bare repo's HEAD when it would otherwise dangle on a deleted branch, keeping subsequent `grove add` invocations working.
- `grove prune` now reaps git-prunable (path-gone) worktrees by default instead of skipping them with a "may be corrupted" warning. Live and locked worktrees are left untouched.