### PR TITLE
fix(prune): reap git-prunable worktrees instead of mislabeling them corrupted

### DIFF
--- a/.changes/unreleased/fixed-prune-prunable-worktrees.yaml
+++ b/.changes/unreleased/fixed-prune-prunable-worktrees.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: '`grove prune` now reaps git-prunable (path-gone) worktrees by default instead of skipping them with a "may be corrupted" warning. Live and locked worktrees are left untouched.'

--- a/cmd/grove/commands/prune.go
+++ b/cmd/grove/commands/prune.go
@@ -318,6 +318,19 @@ func executePrune(bareDir string, candidates []pruneCandidate, force bool, defau
 	var deletedBranches int
 	var keptBranches []string
 
+	// git worktree prune is a single repository-wide operation that reaps every
+	// path-gone entry at once, so run it lazily and share its result across all
+	// prunable candidates instead of invoking it per candidate.
+	prunedRegistry := false
+	var pruneRegistryErr error
+	pruneRegistry := func() error {
+		if !prunedRegistry {
+			pruneRegistryErr = git.PruneWorktrees(bareDir)
+			prunedRegistry = true
+		}
+		return pruneRegistryErr
+	}
+
 	for _, candidate := range candidates {
 		label := formatter.WorktreeLabel(candidate.info)
 		if candidate.pruneType == prunePrunable {
@@ -332,7 +345,7 @@ func executePrune(bareDir string, candidates []pruneCandidate, force bool, defau
 		// Actually remove the worktree
 		var err error
 		if candidate.pruneType == prunePrunable {
-			err = git.PruneWorktrees(bareDir)
+			err = pruneRegistry()
 		} else {
 			err = git.RemoveWorktree(bareDir, candidate.info.Path, force)
 		}

--- a/cmd/grove/commands/prune.go
+++ b/cmd/grove/commands/prune.go
@@ -143,19 +143,24 @@ func runPrune(commit, force bool, stale string, merged, detached bool) error {
 		return fmt.Errorf("failed to list worktrees: %w", err)
 	}
 
-	// Find prune candidates
+	// Find prune candidates. git-prunable (path-gone) worktrees are listed
+	// separately: they are excluded from ListWorktreesWithInfo so they never
+	// leak into other commands, and are reaped by default here.
 	var candidates []pruneCandidate
-	for _, info := range infos {
-		if info.Prunable {
-			reason := determineSkipReason(info, cwd, force)
-			candidates = append(candidates, pruneCandidate{
-				info:      info,
-				reason:    reason,
-				pruneType: prunePrunable,
-			})
-			continue
-		}
 
+	prunables, err := git.ListPrunableWorktrees(bareDir)
+	if err != nil {
+		return fmt.Errorf("failed to list prunable worktrees: %w", err)
+	}
+	for _, info := range prunables {
+		candidates = append(candidates, pruneCandidate{
+			info:      info,
+			reason:    determineSkipReason(info, cwd, force),
+			pruneType: prunePrunable,
+		})
+	}
+
+	for _, info := range infos {
 		// Check for gone upstream
 		if info.Gone {
 			reason := determineSkipReason(info, cwd, force)
@@ -320,15 +325,31 @@ func executePrune(bareDir string, candidates []pruneCandidate, force bool, defau
 
 	// git worktree prune is a single repository-wide operation that reaps every
 	// path-gone entry at once, so run it lazily and share its result across all
-	// prunable candidates instead of invoking it per candidate.
+	// prunable candidates instead of invoking it per candidate. It exits 0 even
+	// when it fails to delete an individual entry, so verify removal per
+	// candidate against the post-prune registry rather than trusting the exit.
 	prunedRegistry := false
 	var pruneRegistryErr error
+	var registeredAfterPrune []string
 	pruneRegistry := func() error {
-		if !prunedRegistry {
-			pruneRegistryErr = git.PruneWorktrees(bareDir)
-			prunedRegistry = true
+		if prunedRegistry {
+			return pruneRegistryErr
 		}
+		prunedRegistry = true
+		pruneRegistryErr = git.PruneWorktrees(bareDir)
+		if pruneRegistryErr != nil {
+			return pruneRegistryErr
+		}
+		registeredAfterPrune, pruneRegistryErr = git.ListWorktrees(bareDir)
 		return pruneRegistryErr
+	}
+	stillRegistered := func(path string) bool {
+		for _, p := range registeredAfterPrune {
+			if fs.PathsEqual(p, path) {
+				return true
+			}
+		}
+		return false
 	}
 
 	for _, candidate := range candidates {
@@ -342,14 +363,23 @@ func executePrune(bareDir string, candidates []pruneCandidate, force bool, defau
 			continue
 		}
 
-		// Actually remove the worktree
-		var err error
+		// git-prunable entries are reaped by the shared prune call; confirm the
+		// entry is actually gone before reporting it pruned.
 		if candidate.pruneType == prunePrunable {
-			err = pruneRegistry()
-		} else {
-			err = git.RemoveWorktree(bareDir, candidate.info.Path, force)
+			if err := pruneRegistry(); err != nil {
+				failed = append(failed, fmt.Sprintf("%s: %v", label, err))
+				continue
+			}
+			if stillRegistered(candidate.info.Path) {
+				failed = append(failed, fmt.Sprintf("%s: git worktree prune did not remove it", label))
+				continue
+			}
+			pruned = append(pruned, label)
+			continue
 		}
-		if err != nil {
+
+		// Actually remove the worktree
+		if err := git.RemoveWorktree(bareDir, candidate.info.Path, force); err != nil {
 			failed = append(failed, fmt.Sprintf("%s: %v", label, err))
 			continue
 		}

--- a/cmd/grove/commands/prune.go
+++ b/cmd/grove/commands/prune.go
@@ -36,6 +36,7 @@ const (
 	pruneDetached pruneType = "detached"
 	pruneStale    pruneType = "stale"
 	pruneMerged   pruneType = "merged"
+	prunePrunable pruneType = "prunable"
 )
 
 // pruneCandidate represents a worktree that could be pruned
@@ -145,6 +146,16 @@ func runPrune(commit, force bool, stale string, merged, detached bool) error {
 	// Find prune candidates
 	var candidates []pruneCandidate
 	for _, info := range infos {
+		if info.Prunable {
+			reason := determineSkipReason(info, cwd, force)
+			candidates = append(candidates, pruneCandidate{
+				info:      info,
+				reason:    reason,
+				pruneType: prunePrunable,
+			})
+			continue
+		}
+
 		// Check for gone upstream
 		if info.Gone {
 			reason := determineSkipReason(info, cwd, force)
@@ -208,11 +219,14 @@ func determineSkipReason(info *git.WorktreeInfo, cwd string, force bool) skipRea
 
 	// Skip reasons that can be overridden with --force
 	if !force {
-		if info.Dirty {
-			return skipDirty
-		}
 		if info.Locked {
 			return skipLocked
+		}
+		if info.Prunable {
+			return skipNone
+		}
+		if info.Dirty {
+			return skipDirty
 		}
 		if info.Ahead > 0 {
 			return skipUnpushed
@@ -234,6 +248,9 @@ func displayDryRun(candidates []pruneCandidate) error {
 
 	for _, candidate := range candidates {
 		label := formatter.WorktreeLabel(candidate.info)
+		if candidate.pruneType == prunePrunable {
+			label = fmt.Sprintf("%s (%s)", label, candidate.pruneType)
+		}
 		if candidate.pruneType == pruneStale && candidate.staleAge != "" {
 			label = fmt.Sprintf("%s (%s)", label, candidate.staleAge)
 		}
@@ -303,6 +320,9 @@ func executePrune(bareDir string, candidates []pruneCandidate, force bool, defau
 
 	for _, candidate := range candidates {
 		label := formatter.WorktreeLabel(candidate.info)
+		if candidate.pruneType == prunePrunable {
+			label = fmt.Sprintf("%s (%s)", label, candidate.pruneType)
+		}
 
 		if candidate.reason != skipNone {
 			skipped = append(skipped, fmt.Sprintf("%s (%s)", label, candidate.reason))
@@ -310,7 +330,13 @@ func executePrune(bareDir string, candidates []pruneCandidate, force bool, defau
 		}
 
 		// Actually remove the worktree
-		if err := git.RemoveWorktree(bareDir, candidate.info.Path, force); err != nil {
+		var err error
+		if candidate.pruneType == prunePrunable {
+			err = git.PruneWorktrees(bareDir)
+		} else {
+			err = git.RemoveWorktree(bareDir, candidate.info.Path, force)
+		}
+		if err != nil {
 			failed = append(failed, fmt.Sprintf("%s: %v", label, err))
 			continue
 		}

--- a/cmd/grove/testdata/script/list_phantom.txt
+++ b/cmd/grove/testdata/script/list_phantom.txt
@@ -1,11 +1,11 @@
-# Test: grove list warns about corrupted (phantom) worktrees
+# Test: grove list shows git-prunable worktrees without corrupted warning
 setup_workspace
 
 exec grove add phantom-test
 rm -r ../phantom-test
-# Grove skips corrupted worktrees and warns
 exec grove list --plain
-stderr 'may be corrupted'
+! stderr 'may be corrupted'
 stdout 'main'
+stdout 'phantom-test'
 # Clean up phantom via git prune
 exec git -C $WORK/workspace/.bare worktree prune

--- a/cmd/grove/testdata/script/list_phantom.txt
+++ b/cmd/grove/testdata/script/list_phantom.txt
@@ -1,11 +1,18 @@
-# Test: grove list shows git-prunable worktrees without corrupted warning
+# Test: git-prunable worktrees are omitted from list/switch without a corrupted warning
 setup_workspace
 
 exec grove add phantom-test
 rm -r ../phantom-test
+
+# grove list omits the path-gone worktree and does not mislabel it as corrupted
 exec grove list --plain
 ! stderr 'may be corrupted'
 stdout 'main'
-stdout 'phantom-test'
+! stdout 'phantom-test'
+
+# grove switch does not resolve a path-gone worktree to its dead path
+! exec grove switch phantom-test
+stderr 'worktree not found'
+
 # Clean up phantom via git prune
 exec git -C $WORK/workspace/.bare worktree prune

--- a/cmd/grove/testdata/script/prune_prunable.txt
+++ b/cmd/grove/testdata/script/prune_prunable.txt
@@ -1,0 +1,30 @@
+# Test: grove prune reaps git-prunable worktrees by default
+setup_workspace feature-gone feature-live feature-locked
+
+exec grove add feature-gone
+exec grove add feature-live
+exec grove add feature-locked
+exec git -C $WORK/workspace/.bare worktree lock ../feature-locked --reason 'keep'
+rm -rf ../feature-gone
+rm -rf ../feature-locked
+
+exec grove prune
+stderr 'Would prune 1 worktree'
+stderr 'feature-gone'
+stderr 'prunable'
+stderr 'Would skip 1 worktree'
+stderr 'feature-locked'
+stderr 'locked, use --force'
+! stderr 'corrupted'
+exists ../feature-live
+
+exec grove prune --commit
+stderr 'Pruned 1 worktree'
+stderr 'feature-gone'
+stderr 'Skipped 1 worktree'
+stderr 'feature-locked'
+! stderr 'corrupted'
+exec git -C $WORK/workspace/.bare worktree list --porcelain
+! stdout 'feature-gone'
+stdout 'feature-live'
+stdout 'feature-locked'

--- a/cmd/grove/testdata/script/prune_prunable.txt
+++ b/cmd/grove/testdata/script/prune_prunable.txt
@@ -14,8 +14,8 @@ rm -rf ../feature-locked
 # untouched (git does not mark locked worktrees prunable), no "corrupted" warning.
 exec grove prune
 stderr 'Would prune 2 worktrees'
-stderr 'feature-gone'
-stderr 'feature-gone2'
+stderr 'feature-gone\b'
+stderr 'feature-gone2\b'
 stderr 'prunable'
 ! stderr 'corrupted'
 exists ../feature-live
@@ -24,8 +24,8 @@ exists ../feature-live
 # each is verified against the registry before being reported pruned.
 exec grove prune --commit
 stderr 'Pruned 2 worktrees'
-stderr 'feature-gone'
-stderr 'feature-gone2'
+stderr 'feature-gone\b'
+stderr 'feature-gone2\b'
 ! stderr 'corrupted'
 
 # The prunable entries are gone from the registry; feature-live and the locked

--- a/cmd/grove/testdata/script/prune_prunable.txt
+++ b/cmd/grove/testdata/script/prune_prunable.txt
@@ -8,22 +8,22 @@ exec git -C $WORK/workspace/.bare worktree lock ../feature-locked --reason 'keep
 rm -rf ../feature-gone
 rm -rf ../feature-locked
 
+# Path-gone worktree is reaped by default; the locked worktree is left untouched
+# (git does not mark locked worktrees prunable), with no "corrupted" warning.
 exec grove prune
 stderr 'Would prune 1 worktree'
 stderr 'feature-gone'
 stderr 'prunable'
-stderr 'Would skip 1 worktree'
-stderr 'feature-locked'
-stderr 'locked, use --force'
 ! stderr 'corrupted'
 exists ../feature-live
 
 exec grove prune --commit
 stderr 'Pruned 1 worktree'
 stderr 'feature-gone'
-stderr 'Skipped 1 worktree'
-stderr 'feature-locked'
 ! stderr 'corrupted'
+
+# feature-gone is reaped from the registry; feature-live and the locked
+# feature-locked remain registered and untouched.
 exec git -C $WORK/workspace/.bare worktree list --porcelain
 ! stdout 'feature-gone'
 stdout 'feature-live'

--- a/cmd/grove/testdata/script/prune_prunable.txt
+++ b/cmd/grove/testdata/script/prune_prunable.txt
@@ -1,28 +1,34 @@
 # Test: grove prune reaps git-prunable worktrees by default
-setup_workspace feature-gone feature-live feature-locked
+setup_workspace feature-gone feature-gone2 feature-live feature-locked
 
 exec grove add feature-gone
+exec grove add feature-gone2
 exec grove add feature-live
 exec grove add feature-locked
 exec git -C $WORK/workspace/.bare worktree lock ../feature-locked --reason 'keep'
 rm -rf ../feature-gone
+rm -rf ../feature-gone2
 rm -rf ../feature-locked
 
-# Path-gone worktree is reaped by default; the locked worktree is left untouched
-# (git does not mark locked worktrees prunable), with no "corrupted" warning.
+# Both path-gone worktrees are reaped by default; the locked worktree is left
+# untouched (git does not mark locked worktrees prunable), no "corrupted" warning.
 exec grove prune
-stderr 'Would prune 1 worktree'
+stderr 'Would prune 2 worktrees'
 stderr 'feature-gone'
+stderr 'feature-gone2'
 stderr 'prunable'
 ! stderr 'corrupted'
 exists ../feature-live
 
+# Committing reaps both prunable entries via a single git worktree prune, and
+# each is verified against the registry before being reported pruned.
 exec grove prune --commit
-stderr 'Pruned 1 worktree'
+stderr 'Pruned 2 worktrees'
 stderr 'feature-gone'
+stderr 'feature-gone2'
 ! stderr 'corrupted'
 
-# feature-gone is reaped from the registry; feature-live and the locked
+# The prunable entries are gone from the registry; feature-live and the locked
 # feature-locked remain registered and untouched.
 exec git -C $WORK/workspace/.bare worktree list --porcelain
 ! stdout 'feature-gone'

--- a/cmd/grove/testdata/script/remove_phantom.txt
+++ b/cmd/grove/testdata/script/remove_phantom.txt
@@ -1,10 +1,9 @@
-# Test: grove remove shows warning for phantom worktree
+# Test: grove remove does not treat git-prunable worktrees as corrupted
 setup_workspace phantom-test
 
 exec grove add phantom-test
 rm -r ../phantom-test
 
-# Grove skips corrupted worktrees and then can't find it
 ! exec grove remove phantom-test
-stderr 'may be corrupted'
-stderr '✗ worktree not found'
+! stderr 'may be corrupted'
+stderr 'failed to check worktree status'

--- a/cmd/grove/testdata/script/remove_phantom.txt
+++ b/cmd/grove/testdata/script/remove_phantom.txt
@@ -4,6 +4,8 @@ setup_workspace phantom-test
 exec grove add phantom-test
 rm -r ../phantom-test
 
+# The path-gone worktree is not a removable target (grove prune reaps it);
+# grove remove reports it as not found rather than mislabeling it corrupted.
 ! exec grove remove phantom-test
 ! stderr 'may be corrupted'
-stderr 'failed to check worktree status'
+stderr 'worktree not found'

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -27,7 +28,19 @@ type WorktreeInfo struct {
 	LockReason     string // Reason for lock (empty if not locked)
 	LastCommitTime int64  // Unix timestamp of last commit (0 if unknown)
 	Detached       bool   // Worktree is in detached HEAD state
+	Prunable       bool   // Git marks the worktree metadata as prunable
 }
+
+type worktreeListEntry struct {
+	Path       string
+	Branch     string
+	Detached   bool
+	Locked     bool
+	LockReason string
+	Prunable   bool
+}
+
+const gitWorktreeSubcommand = "worktree"
 
 // CreateWorktree creates a new worktree from a bare repository
 func CreateWorktree(bareRepo, worktreePath, branch string, quiet bool) error {
@@ -42,7 +55,7 @@ func CreateWorktree(bareRepo, worktreePath, branch string, quiet bool) error {
 	}
 
 	logger.Debug("Executing: git worktree add --relative-paths %s %s", worktreePath, branch)
-	cmd, cancel := GitCommand("git", "worktree", "add", "--relative-paths", worktreePath, branch)
+	cmd, cancel := GitCommand("git", gitWorktreeSubcommand, "add", "--relative-paths", worktreePath, branch)
 	defer cancel()
 	cmd.Dir = bareRepo
 
@@ -63,7 +76,7 @@ func CreateWorktreeWithNewBranch(bareRepo, worktreePath, branch string, quiet bo
 	}
 
 	logger.Debug("Executing: git worktree add --relative-paths -b %s %s", branch, worktreePath)
-	cmd, cancel := GitCommand("git", "worktree", "add", "--relative-paths", "-b", branch, worktreePath)
+	cmd, cancel := GitCommand("git", gitWorktreeSubcommand, "add", "--relative-paths", "-b", branch, worktreePath)
 	defer cancel()
 	cmd.Dir = bareRepo
 
@@ -87,7 +100,7 @@ func CreateWorktreeWithNewBranchFrom(bareRepo, worktreePath, branch, base string
 	}
 
 	logger.Debug("Executing: git worktree add --relative-paths -b %s %s %s", branch, worktreePath, base)
-	cmd, cancel := GitCommand("git", "worktree", "add", "--relative-paths", "-b", branch, worktreePath, base)
+	cmd, cancel := GitCommand("git", gitWorktreeSubcommand, "add", "--relative-paths", "-b", branch, worktreePath, base)
 	defer cancel()
 	cmd.Dir = bareRepo
 
@@ -108,7 +121,7 @@ func CreateWorktreeDetached(bareRepo, worktreePath, ref string, quiet bool) erro
 	}
 
 	logger.Debug("Executing: git worktree add --relative-paths --detach %s %s", worktreePath, ref)
-	cmd, cancel := GitCommand("git", "worktree", "add", "--relative-paths", "--detach", worktreePath, ref)
+	cmd, cancel := GitCommand("git", gitWorktreeSubcommand, "add", "--relative-paths", "--detach", worktreePath, ref)
 	defer cancel()
 	cmd.Dir = bareRepo
 
@@ -117,12 +130,25 @@ func CreateWorktreeDetached(bareRepo, worktreePath, ref string, quiet bool) erro
 
 // RemoveWorktree removes a worktree directory
 func RemoveWorktree(bareDir, worktreePath string, force bool) error {
-	args := []string{"worktree", "remove", worktreePath}
+	args := []string{gitWorktreeSubcommand, "remove", worktreePath}
 	if force {
 		args = append(args, "--force")
 	}
 	logger.Debug("Executing: git %s in %s", strings.Join(args, " "), bareDir)
 	cmd, cancel := GitCommand("git", args...) // nolint:gosec // Worktree path comes from git worktree list
+	defer cancel()
+	cmd.Dir = bareDir
+	return runGitCommand(cmd, true)
+}
+
+// PruneWorktrees removes git-prunable worktree metadata.
+func PruneWorktrees(bareDir string) error {
+	if bareDir == "" {
+		return errors.New("bare directory path cannot be empty")
+	}
+
+	logger.Debug("Executing: git worktree prune in %s", bareDir)
+	cmd, cancel := GitCommand("git", gitWorktreeSubcommand, "prune")
 	defer cancel()
 	cmd.Dir = bareDir
 	return runGitCommand(cmd, true)
@@ -134,7 +160,7 @@ func RepairWorktree(bareDir, worktreePath string) error {
 		return errors.New("bare directory path cannot be empty")
 	}
 
-	args := []string{"worktree", "repair"}
+	args := []string{gitWorktreeSubcommand, "repair"}
 	if worktreePath != "" {
 		args = append(args, worktreePath)
 	}
@@ -149,8 +175,21 @@ func RepairWorktree(bareDir, worktreePath string) error {
 
 // ListWorktrees returns paths to existing worktrees, excluding the main repository
 func ListWorktrees(repoPath string) ([]string, error) {
+	entries, err := listWorktreeEntries(repoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	worktrees := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		worktrees = append(worktrees, entry.Path)
+	}
+	return worktrees, nil
+}
+
+func listWorktreeEntries(repoPath string) ([]worktreeListEntry, error) {
 	logger.Debug("Executing: git worktree list --porcelain in %s", repoPath)
-	cmd, cancel := GitCommand("git", "worktree", "list", "--porcelain")
+	cmd, cancel := GitCommand("git", gitWorktreeSubcommand, "list", "--porcelain")
 	defer cancel()
 	cmd.Dir = repoPath
 
@@ -159,91 +198,130 @@ func ListWorktrees(repoPath string) ([]string, error) {
 		return nil, err
 	}
 
+	return parseWorktreeListPorcelain(out, repoPath)
+}
+
+func parseWorktreeListPorcelain(r io.Reader, repoPath string) ([]worktreeListEntry, error) {
 	absRepoPath, err := filepath.Abs(repoPath)
 	if err != nil {
 		return nil, err
 	}
 
-	var worktrees []string
-	scanner := bufio.NewScanner(out)
-	for scanner.Scan() {
-		line := scanner.Text()
+	var entries []worktreeListEntry
+	var entry worktreeListEntry
 
-		// Porcelain format: "worktree /path/to/worktree" on its own line
-		if !strings.HasPrefix(line, "worktree ") {
-			continue
+	flush := func() error {
+		if entry.Path == "" {
+			return nil
 		}
 
-		worktreePath := strings.TrimPrefix(line, "worktree ")
-		// Normalize path separators (git on Windows uses forward slashes)
-		worktreePath = filepath.FromSlash(worktreePath)
-
+		worktreePath := filepath.FromSlash(entry.Path)
 		absWorktreePath, err := filepath.Abs(worktreePath)
 		if err != nil {
-			return nil, err
+			return err
 		}
+		if !fs.PathsEqual(absWorktreePath, absRepoPath) {
+			entry.Path = absWorktreePath
+			entries = append(entries, entry)
+		}
+		entry = worktreeListEntry{}
+		return nil
+	}
 
-		// Skip the main worktree (same as repo path)
-		// Use fs.PathsEqual for cross-platform comparison (case-insensitive on Windows)
-		if fs.PathsEqual(absWorktreePath, absRepoPath) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if err := flush(); err != nil {
+				return nil, err
+			}
 			continue
 		}
 
-		worktrees = append(worktrees, absWorktreePath)
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			entry.Path = strings.TrimPrefix(line, "worktree ")
+		case strings.HasPrefix(line, "branch "):
+			entry.Branch = strings.TrimPrefix(strings.TrimPrefix(line, "branch "), "refs/heads/")
+		case line == "detached":
+			entry.Detached = true
+			entry.Branch = "(detached)"
+		case line == "locked" || strings.HasPrefix(line, "locked "):
+			entry.Locked = true
+			entry.LockReason = strings.TrimSpace(strings.TrimPrefix(line, "locked"))
+		case line == "prunable" || strings.HasPrefix(line, "prunable "):
+			entry.Prunable = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if err := flush(); err != nil {
+		return nil, err
 	}
 
-	return worktrees, scanner.Err()
+	return entries, nil
 }
 
 // ListWorktreesWithInfo returns info for all worktrees in a grove workspace.
 func ListWorktreesWithInfo(bareDir string, fast bool) ([]*WorktreeInfo, error) {
-	paths, err := ListWorktrees(bareDir)
+	entries, err := listWorktreeEntries(bareDir)
 	if err != nil {
 		return nil, err
 	}
 
 	var infos []*WorktreeInfo
-	for _, path := range paths {
+	for _, entry := range entries {
+		path := entry.Path
 		var info *WorktreeInfo
+		if entry.Prunable {
+			info = &WorktreeInfo{
+				Path:       path,
+				Branch:     entry.Branch,
+				Detached:   entry.Detached,
+				Locked:     entry.Locked,
+				LockReason: entry.LockReason,
+				Prunable:   true,
+			}
+			infos = append(infos, info)
+			continue
+		}
+
 		if fast {
-			branch, detached, err := GetCurrentBranchOrDetached(path)
-			if err != nil {
-				if errors.Is(err, ErrDetachedHead) {
-					info = &WorktreeInfo{
-						Path:     path,
-						Branch:   "(detached)",
-						Detached: true,
-					}
-				} else {
-					logger.Warning("Skipping worktree %s (may be corrupted): %v", path, err)
-					continue
-				}
-			} else {
-				info = &WorktreeInfo{
-					Path:     path,
-					Branch:   branch,
-					Detached: detached,
-				}
+			info = &WorktreeInfo{
+				Path:     path,
+				Branch:   entry.Branch,
+				Detached: entry.Detached,
 			}
 		} else {
 			var err error
 			info, err = GetWorktreeInfo(path)
 			if err != nil {
-				if errors.Is(err, ErrDetachedHead) {
+				switch {
+				case errors.Is(err, ErrDetachedHead):
 					info = &WorktreeInfo{
 						Path:     path,
 						Branch:   "(detached)",
 						Detached: true,
 					}
-				} else {
+				case entry.Locked:
+					info = &WorktreeInfo{
+						Path:       path,
+						Branch:     entry.Branch,
+						Detached:   entry.Detached,
+						Locked:     true,
+						LockReason: entry.LockReason,
+						Prunable:   true,
+					}
+				default:
 					logger.Warning("Skipping worktree %s (may be corrupted): %v", path, err)
 					continue
 				}
 			}
 		}
 
-		info.Locked = IsWorktreeLocked(path)
-		info.LockReason = GetWorktreeLockReason(path)
+		info.Locked = entry.Locked
+		info.LockReason = entry.LockReason
 
 		infos = append(infos, info)
 	}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -311,7 +311,7 @@ func ListWorktreesWithInfo(bareDir string, fast bool) ([]*WorktreeInfo, error) {
 						Detached:   entry.Detached,
 						Locked:     true,
 						LockReason: entry.LockReason,
-						Prunable:   true,
+						Prunable:   entry.Prunable,
 					}
 				default:
 					logger.Warning("Skipping worktree %s (may be corrupted): %v", path, err)

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -263,6 +263,22 @@ func parseWorktreeListPorcelain(r io.Reader, repoPath string) ([]worktreeListEnt
 	return entries, nil
 }
 
+// worktreeFallbackInfo builds a WorktreeInfo for an entry whose status read
+// failed. A detached HEAD or a locked entry is surfaced; anything else is a
+// genuinely corrupt admin entry (gitdir present but unreadable) and is skipped
+// with a warning. The bool is false when the caller should skip the entry.
+func worktreeFallbackInfo(path string, entry worktreeListEntry, err error) (*WorktreeInfo, bool) {
+	switch {
+	case errors.Is(err, ErrDetachedHead):
+		return &WorktreeInfo{Path: path, Branch: "(detached)", Detached: true}, true
+	case entry.Locked:
+		return &WorktreeInfo{Path: path, Branch: entry.Branch, Detached: entry.Detached}, true
+	default:
+		logger.Warning("Skipping worktree %s (may be corrupted): %v", path, err)
+		return nil, false
+	}
+}
+
 // ListWorktreesWithInfo returns info for all worktrees in a grove workspace.
 func ListWorktreesWithInfo(bareDir string, fast bool) ([]*WorktreeInfo, error) {
 	entries, err := listWorktreeEntries(bareDir)
@@ -281,34 +297,25 @@ func ListWorktreesWithInfo(bareDir string, fast bool) ([]*WorktreeInfo, error) {
 			continue
 		}
 
+		// Both modes validate the worktree by reading its HEAD, so a registered
+		// entry whose gitdir is present but unreadable is skipped as corrupt
+		// rather than returned as usable. Fast mode reads only the branch;
+		// full mode also collects status.
 		if fast {
-			info = &WorktreeInfo{
-				Path:     path,
-				Branch:   entry.Branch,
-				Detached: entry.Detached,
+			branch, detached, err := GetCurrentBranchOrDetached(path)
+			if err != nil {
+				var ok bool
+				if info, ok = worktreeFallbackInfo(path, entry, err); !ok {
+					continue
+				}
+			} else {
+				info = &WorktreeInfo{Path: path, Branch: branch, Detached: detached}
 			}
 		} else {
 			var err error
-			info, err = GetWorktreeInfo(path)
-			if err != nil {
-				switch {
-				case errors.Is(err, ErrDetachedHead):
-					info = &WorktreeInfo{
-						Path:     path,
-						Branch:   "(detached)",
-						Detached: true,
-					}
-				case entry.Locked:
-					// A locked worktree whose path is unreadable: surface it as
-					// a locked entry (lock fields are set below) rather than
-					// warning "may be corrupted".
-					info = &WorktreeInfo{
-						Path:     path,
-						Branch:   entry.Branch,
-						Detached: entry.Detached,
-					}
-				default:
-					logger.Warning("Skipping worktree %s (may be corrupted): %v", path, err)
+			if info, err = GetWorktreeInfo(path); err != nil {
+				var ok bool
+				if info, ok = worktreeFallbackInfo(path, entry, err); !ok {
 					continue
 				}
 			}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -274,16 +274,10 @@ func ListWorktreesWithInfo(bareDir string, fast bool) ([]*WorktreeInfo, error) {
 	for _, entry := range entries {
 		path := entry.Path
 		var info *WorktreeInfo
+		// git-prunable entries have no backing path, so they are not usable
+		// worktrees for callers that switch/exec/add against them. Only
+		// `grove prune` acts on them, via ListPrunableWorktrees.
 		if entry.Prunable {
-			info = &WorktreeInfo{
-				Path:       path,
-				Branch:     entry.Branch,
-				Detached:   entry.Detached,
-				Locked:     entry.Locked,
-				LockReason: entry.LockReason,
-				Prunable:   true,
-			}
-			infos = append(infos, info)
 			continue
 		}
 
@@ -305,13 +299,13 @@ func ListWorktreesWithInfo(bareDir string, fast bool) ([]*WorktreeInfo, error) {
 						Detached: true,
 					}
 				case entry.Locked:
+					// A locked worktree whose path is unreadable: surface it as
+					// a locked entry (lock fields are set below) rather than
+					// warning "may be corrupted".
 					info = &WorktreeInfo{
-						Path:       path,
-						Branch:     entry.Branch,
-						Detached:   entry.Detached,
-						Locked:     true,
-						LockReason: entry.LockReason,
-						Prunable:   entry.Prunable,
+						Path:     path,
+						Branch:   entry.Branch,
+						Detached: entry.Detached,
 					}
 				default:
 					logger.Warning("Skipping worktree %s (may be corrupted): %v", path, err)
@@ -330,6 +324,36 @@ func ListWorktreesWithInfo(bareDir string, fast bool) ([]*WorktreeInfo, error) {
 		return infos[i].Branch < infos[j].Branch
 	})
 
+	return infos, nil
+}
+
+// ListPrunableWorktrees returns the worktrees git has marked prunable, i.e.
+// their backing path is gone. These are excluded from ListWorktreesWithInfo
+// because they are not usable worktrees; only `grove prune` acts on them.
+func ListPrunableWorktrees(bareDir string) ([]*WorktreeInfo, error) {
+	if bareDir == "" {
+		return nil, errors.New("bare directory path cannot be empty")
+	}
+
+	entries, err := listWorktreeEntries(bareDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var infos []*WorktreeInfo
+	for _, entry := range entries {
+		if !entry.Prunable {
+			continue
+		}
+		infos = append(infos, &WorktreeInfo{
+			Path:       entry.Path,
+			Branch:     entry.Branch,
+			Detached:   entry.Detached,
+			Locked:     entry.Locked,
+			LockReason: entry.LockReason,
+			Prunable:   true,
+		})
+	}
 	return infos, nil
 }
 

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -455,6 +455,43 @@ func TestListWorktreesWithInfo(t *testing.T) {
 		}
 	})
 
+	t.Run("skips corrupt-but-present worktrees in both modes", func(t *testing.T) {
+		for _, fast := range []bool{false, true} {
+			repo := testgit.NewTestRepo(t)
+
+			liveDir := filepath.Join(repo.TempDir, "live-wt")
+			cmd := exec.Command("git", "worktree", "add", liveDir, "-b", "live") // nolint:gosec // Test uses controlled temp directory
+			cmd.Dir = repo.Path
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("failed to create live worktree: %v", err)
+			}
+
+			// A worktree whose directory is present but whose .git pointer is
+			// unreadable: git still lists it (no prunable marker), so it must be
+			// skipped by validation, not returned as usable.
+			corruptDir := filepath.Join(repo.TempDir, "corrupt-wt")
+			cmd = exec.Command("git", "worktree", "add", corruptDir, "-b", "corrupt") // nolint:gosec // Test uses controlled temp directory
+			cmd.Dir = repo.Path
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("failed to create corrupt worktree: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(corruptDir, ".git"), []byte("garbage"), fs.FileStrict); err != nil {
+				t.Fatalf("failed to corrupt .git: %v", err)
+			}
+
+			infos, err := ListWorktreesWithInfo(repo.Path, fast)
+			if err != nil {
+				t.Fatalf("ListWorktreesWithInfo(fast=%v) failed: %v", fast, err)
+			}
+
+			for _, info := range infos {
+				if filepath.Base(info.Path) == "corrupt-wt" {
+					t.Fatalf("fast=%v: corrupt worktree should be skipped, got %#v", fast, info)
+				}
+			}
+		}
+	})
+
 	t.Run("results are sorted alphabetically", func(t *testing.T) {
 		repo := testgit.NewTestRepo(t)
 

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -420,6 +420,41 @@ func TestListWorktreesWithInfo(t *testing.T) {
 		}
 	})
 
+	t.Run("excludes git-prunable worktrees in both modes", func(t *testing.T) {
+		for _, fast := range []bool{false, true} {
+			repo := testgit.NewTestRepo(t)
+
+			liveDir := filepath.Join(repo.TempDir, "live-wt")
+			cmd := exec.Command("git", "worktree", "add", liveDir, "-b", "live") // nolint:gosec // Test uses controlled temp directory
+			cmd.Dir = repo.Path
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("failed to create live worktree: %v", err)
+			}
+
+			goneDir := filepath.Join(repo.TempDir, "gone-wt")
+			cmd = exec.Command("git", "worktree", "add", goneDir, "-b", "gone") // nolint:gosec // Test uses controlled temp directory
+			cmd.Dir = repo.Path
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("failed to create gone worktree: %v", err)
+			}
+			if err := os.RemoveAll(goneDir); err != nil {
+				t.Fatalf("failed to remove worktree dir: %v", err)
+			}
+
+			infos, err := ListWorktreesWithInfo(repo.Path, fast)
+			if err != nil {
+				t.Fatalf("ListWorktreesWithInfo(fast=%v) failed: %v", fast, err)
+			}
+
+			if len(infos) != 1 {
+				t.Fatalf("fast=%v: expected 1 worktree (prunable excluded), got %d: %#v", fast, len(infos), infos)
+			}
+			if filepath.Base(infos[0].Path) != "live-wt" {
+				t.Fatalf("fast=%v: expected the live worktree, got %#v", fast, infos[0])
+			}
+		}
+	})
+
 	t.Run("results are sorted alphabetically", func(t *testing.T) {
 		repo := testgit.NewTestRepo(t)
 
@@ -578,6 +613,66 @@ func TestListWorktreesWithInfo(t *testing.T) {
 
 		if infos[0].Branch == "" {
 			t.Error("expected Branch to contain commit hash, got empty string")
+		}
+	})
+}
+
+func TestListPrunableWorktrees(t *testing.T) {
+	t.Run("returns error for empty bare directory", func(t *testing.T) {
+		if _, err := ListPrunableWorktrees(""); err == nil {
+			t.Fatal("expected error for empty bare directory")
+		}
+	})
+
+	t.Run("returns only path-gone worktrees", func(t *testing.T) {
+		repo := testgit.NewTestRepo(t)
+
+		liveDir := filepath.Join(repo.TempDir, "live-wt")
+		cmd := exec.Command("git", "worktree", "add", liveDir, "-b", "live") // nolint:gosec // Test uses controlled temp directory
+		cmd.Dir = repo.Path
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("failed to create live worktree: %v", err)
+		}
+
+		goneDir := filepath.Join(repo.TempDir, "gone-wt")
+		cmd = exec.Command("git", "worktree", "add", goneDir, "-b", "gone") // nolint:gosec // Test uses controlled temp directory
+		cmd.Dir = repo.Path
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("failed to create gone worktree: %v", err)
+		}
+		if err := os.RemoveAll(goneDir); err != nil {
+			t.Fatalf("failed to remove worktree dir: %v", err)
+		}
+
+		infos, err := ListPrunableWorktrees(repo.Path)
+		if err != nil {
+			t.Fatalf("ListPrunableWorktrees failed: %v", err)
+		}
+
+		if len(infos) != 1 {
+			t.Fatalf("expected 1 prunable worktree, got %d: %#v", len(infos), infos)
+		}
+		if filepath.Base(infos[0].Path) != "gone-wt" || !infos[0].Prunable {
+			t.Fatalf("expected the path-gone worktree marked prunable, got %#v", infos[0])
+		}
+	})
+
+	t.Run("returns empty when nothing is prunable", func(t *testing.T) {
+		repo := testgit.NewTestRepo(t)
+
+		liveDir := filepath.Join(repo.TempDir, "live-wt")
+		cmd := exec.Command("git", "worktree", "add", liveDir, "-b", "live") // nolint:gosec // Test uses controlled temp directory
+		cmd.Dir = repo.Path
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("failed to create live worktree: %v", err)
+		}
+
+		infos, err := ListPrunableWorktrees(repo.Path)
+		if err != nil {
+			t.Fatalf("ListPrunableWorktrees failed: %v", err)
+		}
+		if len(infos) != 0 {
+			t.Fatalf("expected no prunable worktrees, got %d: %#v", len(infos), infos)
 		}
 	})
 }

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -143,6 +143,43 @@ func TestIsWorktree(t *testing.T) {
 }
 
 func TestListWorktrees(t *testing.T) {
+	t.Run("parses porcelain metadata for live and prunable worktrees", func(t *testing.T) {
+		repo := testgit.NewTestRepo(t)
+		livePath := filepath.Join(repo.TempDir, "feature-worktree")
+		gonePath := filepath.Join(repo.TempDir, "gone-worktree")
+
+		input := strings.NewReader(strings.Join([]string{
+			"worktree " + repo.Path,
+			"HEAD 0000000000000000000000000000000000000000",
+			"branch refs/heads/main",
+			"",
+			"worktree " + livePath,
+			"HEAD 1111111111111111111111111111111111111111",
+			"branch refs/heads/feature",
+			"",
+			"worktree " + gonePath,
+			"HEAD 2222222222222222222222222222222222222222",
+			"branch refs/heads/gone",
+			"prunable gitdir file points to non-existent location",
+			"",
+		}, "\n"))
+
+		entries, err := parseWorktreeListPorcelain(input, repo.Path)
+		if err != nil {
+			t.Fatalf("parseWorktreeListPorcelain failed: %v", err)
+		}
+
+		if len(entries) != 2 {
+			t.Fatalf("expected 2 worktrees, got %d: %#v", len(entries), entries)
+		}
+		if entries[0].Path != livePath || entries[0].Branch != "feature" || entries[0].Prunable {
+			t.Fatalf("live entry parsed incorrectly: %#v", entries[0])
+		}
+		if entries[1].Path != gonePath || entries[1].Branch != "gone" || !entries[1].Prunable {
+			t.Fatalf("prunable entry parsed incorrectly: %#v", entries[1])
+		}
+	})
+
 	t.Run("returns empty slice when no worktrees", func(t *testing.T) {
 		repo := testgit.NewTestRepo(t)
 

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -180,6 +180,41 @@ func TestListWorktrees(t *testing.T) {
 		}
 	})
 
+	t.Run("parses locked, lock reason, and detached markers", func(t *testing.T) {
+		repo := testgit.NewTestRepo(t)
+		lockedPath := filepath.Join(repo.TempDir, "locked-worktree")
+		detachedPath := filepath.Join(repo.TempDir, "detached-worktree")
+
+		input := strings.NewReader(strings.Join([]string{
+			"worktree " + lockedPath,
+			"HEAD 1111111111111111111111111111111111111111",
+			"branch refs/heads/feature",
+			"locked keeping this around",
+			"",
+			"worktree " + detachedPath,
+			"HEAD 2222222222222222222222222222222222222222",
+			"detached",
+			"",
+		}, "\n"))
+
+		entries, err := parseWorktreeListPorcelain(input, repo.Path)
+		if err != nil {
+			t.Fatalf("parseWorktreeListPorcelain failed: %v", err)
+		}
+
+		if len(entries) != 2 {
+			t.Fatalf("expected 2 worktrees, got %d: %#v", len(entries), entries)
+		}
+		locked := entries[0]
+		if locked.Path != lockedPath || !locked.Locked || locked.LockReason != "keeping this around" || locked.Detached {
+			t.Fatalf("locked entry parsed incorrectly: %#v", locked)
+		}
+		detached := entries[1]
+		if detached.Path != detachedPath || !detached.Detached || detached.Branch != "(detached)" || detached.Locked {
+			t.Fatalf("detached entry parsed incorrectly: %#v", detached)
+		}
+	})
+
 	t.Run("returns empty slice when no worktrees", func(t *testing.T) {
 		repo := testgit.NewTestRepo(t)
 


### PR DESCRIPTION
## Summary

`grove prune` now reaps git-prunable (path-gone) worktrees by default instead of mislabeling them "corrupted" and refusing to clean them.

Transient worktrees created by other tools (e.g. fallow's `/tmp/fallow-audit-base-cache-*`) get orphaned when their backing path is wiped before the creating tool cleans up. Their registry entries linger and surface in any tool that reads git's worktree registry directly (Orca, Zed). Previously `grove prune` stat'd `.git` for every worktree and bailed when that failed, mislabeling a routine stale entry as "may be corrupted" — so it was the only thing in the way of `git worktree prune` clearing them.

## Changes

- **Trust git's `prunable` verdict.** `git worktree list --porcelain` is now parsed block-by-block (`internal/git/worktree.go`), capturing the `prunable`, `locked`, `branch`, and `detached` markers.
- **`prunable` is a first-class prune category, reaped by default** (`cmd/grove/commands/prune.go`). No `--force`, not gated behind `--detached`. The path-gone class delegates removal to `git worktree prune`, and each candidate is verified against the registry afterward (that command exits 0 even on partial failure).
- **Prunable phantoms are scoped to `grove prune` only.** They are excluded from `ListWorktreesWithInfo` (via a dedicated `ListPrunableWorktrees` accessor) so they never leak into `switch`/`exec`/`add`/`remove`, where a path-gone entry would otherwise resolve to a dead directory.
- **"may be corrupted" is reserved** for genuinely unreadable admin entries, not routine stale ones.
- Live worktrees (present path) are never touched; locked worktrees are respected (git never marks a locked worktree prunable, so they are left untouched by default).

## Test plan

- `cmd/grove/testdata/script/prune_prunable.txt`: two path-gone worktrees are reaped by a single batched prune (each verified against the registry); a live worktree and a locked+path-gone worktree are untouched; no "corrupted" warning.
- `list_phantom.txt` / `remove_phantom.txt`: a path-gone worktree is omitted from `grove list` and `grove switch`, and `grove remove` reports it not found — never "corrupted".
- Unit tests for the porcelain parser (`branch`/`prunable`/`locked`/`detached`), `ListPrunableWorktrees`, and the `ListWorktreesWithInfo` exclusion (fast and full modes).
- `make ci` green (770 tests, lint, build).

Fixes ABU-174
