### PR TITLE
fix(logger): suppress the spinner when stderr is not a TTY

### DIFF
--- a/.changes/unreleased/fixed-spinner-non-tty.yaml
+++ b/.changes/unreleased/fixed-spinner-non-tty.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: 'Spinners now print a single plain `→ message` line instead of animating when stderr is not a terminal, so piped and CI output no longer contains cursor-control sequences. `--plain` still takes precedence.'

--- a/cmd/grove/testdata/script/list_non_tty_spinner.txt
+++ b/cmd/grove/testdata/script/list_non_tty_spinner.txt
@@ -1,0 +1,8 @@
+# Test: grove list prints one plain spinner line when stderr is not a TTY
+setup_workspace
+
+exec grove list
+stdout 'main'
+stderr -count=1 'Gathering worktree status'
+stderr '^→ Gathering worktree status\.\.\.$'
+! stderr '\x1b\['

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -11,9 +11,10 @@ import (
 
 // Logger state - initialized once at startup, read from goroutines
 var (
-	plainMode atomic.Bool
-	debugMode atomic.Bool
-	output    atomic.Pointer[io.Writer]
+	plainMode      atomic.Bool
+	debugMode      atomic.Bool
+	stderrTerminal atomic.Bool
+	output         atomic.Pointer[io.Writer]
 )
 
 // Init initializes the logger with the given settings.
@@ -21,6 +22,8 @@ var (
 func Init(plain, debug bool) {
 	plainMode.Store(plain)
 	debugMode.Store(debug)
+	info, err := os.Stderr.Stat()
+	stderrTerminal.Store(err == nil && info.Mode()&os.ModeCharDevice != 0)
 }
 
 // SetOutput sets the output writer for logging.
@@ -49,6 +52,10 @@ func getOutput() io.Writer {
 // isPlain returns true if plain output mode is enabled
 func isPlain() bool {
 	return plainMode.Load()
+}
+
+func stderrIsTerminal() bool {
+	return stderrTerminal.Load()
 }
 
 // isDebug returns true if debug logging is enabled

--- a/internal/logger/spinner.go
+++ b/internal/logger/spinner.go
@@ -21,8 +21,8 @@ func StartSpinner(message string) *Spinner {
 	s := &Spinner{done: make(chan struct{})}
 	s.message.Store(message)
 
-	if isPlain() {
-		fmt.Fprintf(os.Stderr, "%s %s\n", styles.Render(&styles.Info, "→"), message)
+	if isPlain() || !stderrIsTerminal() {
+		fmt.Fprintf(os.Stderr, "→ %s\n", message)
 		s.once.Do(func() { close(s.done) })
 		return s
 	}

--- a/internal/logger/spinner_test.go
+++ b/internal/logger/spinner_test.go
@@ -176,13 +176,28 @@ func TestSpinnerTerminal(t *testing.T) {
 	Init(false, false)
 	stderrTerminal.Store(true)
 	spinner := StartSpinner("Gathering worktree status...")
-	time.Sleep(100 * time.Millisecond)
-	spinner.Stop()
-
-	_ = w.Close()
 
 	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
+	firstFrame := make(chan struct{})
+	drained := make(chan struct{})
+	go func() {
+		chunk := make([]byte, 64)
+		n, _ := r.Read(chunk)
+		buf.Write(chunk[:n])
+		close(firstFrame)
+		_, _ = io.Copy(&buf, r)
+		close(drained)
+	}()
+
+	select {
+	case <-firstFrame:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no spinner frame written within 5s")
+	}
+	spinner.Stop()
+	_ = w.Close()
+	<-drained
+
 	output := buf.String()
 	if !strings.Contains(output, "\r") || !strings.ContainsAny(output, "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏") {
 		t.Errorf("spinner output = %q, want animation", output)

--- a/internal/logger/spinner_test.go
+++ b/internal/logger/spinner_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sqve/grove/internal/config"
 )
@@ -101,6 +102,7 @@ func TestSpinnerPlainMode(t *testing.T) {
 
 		config.SetPlain(true)
 		Init(true, false)
+		stderrTerminal.Store(true)
 		spinner := StartSpinner("Loading data")
 		spinner.Stop()
 
@@ -123,6 +125,7 @@ func TestSpinnerPlainMode(t *testing.T) {
 
 		config.SetPlain(true)
 		Init(true, false)
+		stderrTerminal.Store(true)
 		spinner := StartSpinner("test")
 		spinner.Update("updated")
 		spinner.Stop()
@@ -140,4 +143,48 @@ func TestSpinnerPlainMode(t *testing.T) {
 			t.Error("Plain mode should not show spinner frames")
 		}
 	})
+}
+
+func TestSpinnerNonTerminal(t *testing.T) {
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = oldStderr })
+
+	config.SetPlain(false)
+	Init(false, false)
+	stderrTerminal.Store(false)
+	spinner := StartSpinner("Gathering worktree status...")
+	spinner.Stop()
+
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	if got, want := buf.String(), "→ Gathering worktree status...\n"; got != want {
+		t.Errorf("spinner output = %q, want %q", got, want)
+	}
+}
+
+func TestSpinnerTerminal(t *testing.T) {
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = oldStderr })
+
+	config.SetPlain(false)
+	Init(false, false)
+	stderrTerminal.Store(true)
+	spinner := StartSpinner("Gathering worktree status...")
+	time.Sleep(100 * time.Millisecond)
+	spinner.Stop()
+
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	output := buf.String()
+	if !strings.Contains(output, "\r") || !strings.ContainsAny(output, "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏") {
+		t.Errorf("spinner output = %q, want animation", output)
+	}
 }


### PR DESCRIPTION
Suppress the animated spinner when stderr is not a terminal, so agents, CI logs, and anyone piping grove output get a single plain progress line instead of cursor-control sequences.

#### Changes

- The logger decides stderr's TTY state once at startup in `logger.Init` from the file mode, so tests can force either path deterministically.
- `StartSpinner` falls back to the one-line `→ message` form whenever stderr is a pipe or file. `--plain` keeps precedence because it is checked first.
- The fallback line is written without styling so no colour escape leaks onto piped stderr when stdout is still a terminal. `--plain` output is byte-identical to before.
- Every spinner call site already routes through `StartSpinner`, so no command files change. No new dependency.
- Changelog entry under Fixed.

#### Test plan

- [x] Code review by Claude Opus 5 (cape:code-reviewer) on f5321c4, findings addressed or dismissed
- [x] `make ci`
- [x] `go test ./internal/logger/` covers TTY true (animates), TTY false (single plain line), and `--plain` precedence
- [x] Script test `list_non_tty_spinner.txt`: `grove list` without `--plain` writes exactly one `→ Gathering worktree status...` line and no `ESC[` sequence to stderr
- [x] Built binary: `grove list 2>err.txt` in a workspace leaves zero escape bytes in err.txt
- [x] Built binary: `grove --plain list 2>err.txt` output unchanged

#### Verification performed

- `make ci` passes with the go.mod toolchain (Go 1.25.8).
- Ran the built binary in a real grove workspace with stderr redirected: one plain line, zero escape bytes. Same with `--plain`.
- Existing `list_*.txt` script tests continue to pass.

---

Fixes ABU-261, AI-38