### PR TITLE
fix(add): release the workspace lock before hooks and wait on contention

### DIFF
--- a/.changes/unreleased/fixed-87.yaml
+++ b/.changes/unreleased/fixed-87.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Release the workspace lock before add hooks and wait for concurrent operations.
+time: 2026-09-03T11:50:40.490062568+02:00
+custom:
+  Issue: '87'

--- a/.changes/unreleased/fixed-87.yaml
+++ b/.changes/unreleased/fixed-87.yaml
@@ -1,5 +1,0 @@
-kind: Fixed
-body: Release the workspace lock before add hooks and wait for concurrent operations.
-time: 2026-09-03T11:50:40.490062568+02:00
-custom:
-  Issue: '87'

--- a/.changes/unreleased/fixed-add-lock-before-hooks.yaml
+++ b/.changes/unreleased/fixed-add-lock-before-hooks.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: '`grove add` now releases the workspace lock before running hooks, and lock contention waits up to 60 seconds for the other operation instead of failing immediately.'
+time: 2026-09-03T11:50:40.490062568+02:00

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -144,10 +144,15 @@ func runAdd(args []string, switchTo bool, baseBranch, name string, detach bool, 
 	if err != nil {
 		return err
 	}
-	defer func() {
+	releaseLock := func() {
+		if lockHandle == nil {
+			return
+		}
 		_ = lockHandle.Close()
 		_ = os.Remove(lockFile)
-	}()
+		lockHandle = nil
+	}
+	defer releaseLock()
 
 	spin := logger.StartSpinner("Preparing workspace...")
 	var sourceWorktree string
@@ -184,24 +189,24 @@ func runAdd(args []string, switchTo bool, baseBranch, name string, detach bool, 
 	// Handle PR via --pr flag
 	if prFlag {
 		prRef := fmt.Sprintf("#%d", prNumber)
-		return runAddFromPR(prRef, switchTo, name, bareDir, workspaceRoot, sourceWorktree, reset)
+		return runAddFromPR(prRef, switchTo, name, bareDir, workspaceRoot, sourceWorktree, reset, releaseLock)
 	}
 
 	// Handle PR via URL
 	if isPRURL {
-		return runAddFromPR(branchOrPR, switchTo, name, bareDir, workspaceRoot, sourceWorktree, reset)
+		return runAddFromPR(branchOrPR, switchTo, name, bareDir, workspaceRoot, sourceWorktree, reset, releaseLock)
 	}
 
 	// Detached worktree
 	if detach {
-		return runAddDetached(branchOrPR, switchTo, name, bareDir, workspaceRoot, sourceWorktree)
+		return runAddDetached(branchOrPR, switchTo, name, bareDir, workspaceRoot, sourceWorktree, releaseLock)
 	}
 
 	// Regular branch creation
-	return runAddFromBranch(branchOrPR, switchTo, baseBranch, name, bareDir, workspaceRoot, sourceWorktree)
+	return runAddFromBranch(branchOrPR, switchTo, baseBranch, name, bareDir, workspaceRoot, sourceWorktree, releaseLock)
 }
 
-func runAddFromBranch(branch string, switchTo bool, baseBranch, name, bareDir, workspaceRoot, sourceWorktree string) error {
+func runAddFromBranch(branch string, switchTo bool, baseBranch, name, bareDir, workspaceRoot, sourceWorktree string, releaseLock func()) error {
 	dirName := name
 	if dirName == "" {
 		dirName = workspace.SanitizeBranchName(branch)
@@ -268,6 +273,7 @@ func runAddFromBranch(branch string, switchTo bool, baseBranch, name, bareDir, w
 		}
 	}
 
+	releaseLock()
 	spin := logger.StartSpinner("Setting up worktree...")
 	configWorktree := findConfigWorktree(bareDir)
 	preserveResult := preserveFilesFromSource(sourceWorktree, worktreePath, configWorktree)
@@ -286,7 +292,7 @@ func runAddFromBranch(branch string, switchTo bool, baseBranch, name, bareDir, w
 	return nil
 }
 
-func runAddDetached(ref string, switchTo bool, name, bareDir, workspaceRoot, sourceWorktree string) error {
+func runAddDetached(ref string, switchTo bool, name, bareDir, workspaceRoot, sourceWorktree string, releaseLock func()) error {
 	dirName := name
 	if dirName == "" {
 		dirName = workspace.SanitizeBranchName(ref)
@@ -309,6 +315,7 @@ func runAddDetached(ref string, switchTo bool, name, bareDir, workspaceRoot, sou
 
 	// Note: Auto-lock not applied for detached worktrees (no branch to lock)
 
+	releaseLock()
 	spin := logger.StartSpinner("Setting up worktree...")
 	configWorktree := findConfigWorktree(bareDir)
 	preserveResult := preserveFilesFromSource(sourceWorktree, worktreePath, configWorktree)
@@ -327,7 +334,7 @@ func runAddDetached(ref string, switchTo bool, name, bareDir, workspaceRoot, sou
 	return nil
 }
 
-func runAddFromPR(prRef string, switchTo bool, name, bareDir, workspaceRoot, sourceWorktree string, reset bool) error {
+func runAddFromPR(prRef string, switchTo bool, name, bareDir, workspaceRoot, sourceWorktree string, reset bool, releaseLock func()) error {
 	// Check gh is available
 	if err := github.CheckGhAvailable(); err != nil {
 		return err
@@ -492,6 +499,7 @@ func runAddFromPR(prRef string, switchTo bool, name, bareDir, workspaceRoot, sou
 		}
 	}
 
+	releaseLock()
 	setupSpin := logger.StartSpinner("Setting up worktree...")
 	configWorktree := findConfigWorktree(bareDir)
 	preserveResult := preserveFilesFromSource(sourceWorktree, worktreePath, configWorktree)

--- a/cmd/grove/testdata/script/add_concurrent_hooks.txt
+++ b/cmd/grove/testdata/script/add_concurrent_hooks.txt
@@ -1,0 +1,19 @@
+# Test: concurrent adds proceed while an earlier add runs a slow hook
+[windows] skip
+setup_workspace
+
+cp $WORK/grove-hooks-slow.toml .grove.toml
+
+exec grove add feature/slow-hook &
+exec sh -c 'while [ ! -e "$WORK/hook-started" ]; do sleep 0.05; done'
+rm .grove.toml
+exec grove add feature/concurrent
+wait
+
+exists $WORK/workspace/feature-slow-hook
+exists $WORK/workspace/feature-concurrent
+exists $WORK/concurrent-during-hook
+
+-- grove-hooks-slow.toml --
+[hooks]
+add = ['touch "$WORK/hook-started"; sleep 2; test -d "$WORK/workspace/feature-concurrent" && touch "$WORK/concurrent-during-hook"']

--- a/cmd/grove/testdata/script/add_concurrent_hooks.txt
+++ b/cmd/grove/testdata/script/add_concurrent_hooks.txt
@@ -16,4 +16,4 @@ exists $WORK/concurrent-during-hook
 
 -- grove-hooks-slow.toml --
 [hooks]
-add = ['touch "$WORK/hook-started"; sleep 2; test -d "$WORK/workspace/feature-concurrent" && touch "$WORK/concurrent-during-hook"']
+add = ['touch "$WORK/hook-started"; for i in $(seq 1 100); do if test -d "$WORK/workspace/feature-concurrent"; then touch "$WORK/concurrent-during-hook"; break; fi; sleep 0.1; done']

--- a/cmd/grove/testdata/script/add_concurrent_hooks.txt
+++ b/cmd/grove/testdata/script/add_concurrent_hooks.txt
@@ -5,7 +5,7 @@ setup_workspace
 cp $WORK/grove-hooks-slow.toml .grove.toml
 
 exec grove add feature/slow-hook &
-exec sh -c 'while [ ! -e "$WORK/hook-started" ]; do sleep 0.05; done'
+exec sh -c 'i=0; while [ ! -e "$WORK/hook-started" ]; do i=$((i+1)); [ "$i" -lt 200 ] || exit 1; sleep 0.05; done'
 rm .grove.toml
 exec grove add feature/concurrent
 wait

--- a/internal/workspace/lock.go
+++ b/internal/workspace/lock.go
@@ -90,7 +90,7 @@ func tryAcquireLock(lockFile string, attempt int) (*os.File, bool, error) {
 
 	pidStr := strings.TrimSpace(string(content))
 	pid, parseErr := strconv.Atoi(pidStr)
-	if parseErr != nil {
+	if parseErr != nil || pid <= 0 {
 		// Invalid PID means corrupted lock file - treat as stale and retry
 		logger.Debug("Lock file contains invalid PID %q, removing stale lock (attempt %d)", pidStr, attempt+1)
 		_ = os.Remove(lockFile)

--- a/internal/workspace/lock.go
+++ b/internal/workspace/lock.go
@@ -73,8 +73,11 @@ func tryAcquireLock(lockFile string, attempt int) (*os.File, bool, error) {
 
 	// Lock file exists - check if it's stale
 	info, statErr := os.Stat(lockFile)
-	if statErr != nil {
+	if errors.Is(statErr, os.ErrNotExist) {
 		return nil, false, errLockReleased
+	}
+	if statErr != nil {
+		return nil, true, fmt.Errorf("failed to inspect lock: %w", statErr)
 	}
 
 	content, readErr := os.ReadFile(lockFile) //nolint:gosec // path derived from validated workspace

--- a/internal/workspace/lock.go
+++ b/internal/workspace/lock.go
@@ -11,6 +11,10 @@ import (
 	"github.com/sqve/grove/internal/logger"
 )
 
+// errLockReleased marks a lock file that vanished between the exclusive create
+// and the staleness check; the holder just released it, so poll again.
+var errLockReleased = errors.New("lock released during check")
+
 const (
 	maxLockRetries   = 3
 	lockWaitTimeout  = 60 * time.Second
@@ -26,30 +30,32 @@ const (
 // Stale locks (from crashed processes) are automatically removed.
 func AcquireWorkspaceLock(lockFile string) (*os.File, error) {
 	deadline := time.Now().Add(lockWaitTimeout)
-	for attempt := range maxLockRetries {
-		for {
-			lockHandle, done, err := tryAcquireLock(lockFile, attempt)
-			if done {
-				return lockHandle, err
-			}
-			if err == nil {
-				break
-			}
-
-			remaining := time.Until(deadline)
-			if remaining <= 0 {
-				return nil, err
-			}
-			time.Sleep(min(lockPollInterval, remaining))
+	staleRemovals := 0
+	for {
+		lockHandle, done, err := tryAcquireLock(lockFile, staleRemovals)
+		if done {
+			return lockHandle, err
 		}
+		if err == nil {
+			staleRemovals++
+			if staleRemovals >= maxLockRetries {
+				return nil, fmt.Errorf("failed to acquire lock after %d attempts; if no grove operation is running, remove %s", maxLockRetries, lockFile)
+			}
+			continue
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, err
+		}
+		time.Sleep(min(lockPollInterval, remaining))
 	}
-	return nil, fmt.Errorf("failed to acquire lock after %d attempts; if no grove operation is running, remove %s", maxLockRetries, lockFile)
 }
 
 // tryAcquireLock makes a single attempt to acquire the lock.
 // Returns (handle, true, nil) on success, (nil, true, err) on permanent failure,
-// (nil, false, err) if a live process holds the lock, or (nil, false, nil) if a
-// stale lock was removed and retry is needed.
+// (nil, false, nil) if a stale lock was removed, or (nil, false, err) if the lock
+// is held by a live process or was released mid-check and the caller should poll.
 func tryAcquireLock(lockFile string, attempt int) (*os.File, bool, error) {
 	lockHandle, err := os.OpenFile(lockFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600) //nolint:gosec // path derived from validated workspace
 	if err == nil {
@@ -65,11 +71,13 @@ func tryAcquireLock(lockFile string, attempt int) (*os.File, bool, error) {
 	// Lock file exists - check if it's stale
 	info, statErr := os.Stat(lockFile)
 	if statErr != nil {
-		// File disappeared between OpenFile and Stat - retry
-		return nil, false, nil //nolint:nilerr // intentional: file gone, retry
+		return nil, false, errLockReleased
 	}
 
 	content, readErr := os.ReadFile(lockFile) //nolint:gosec // path derived from validated workspace
+	if errors.Is(readErr, os.ErrNotExist) {
+		return nil, false, errLockReleased
+	}
 	if readErr != nil {
 		return nil, true, fmt.Errorf("another grove operation is in progress; if this is wrong, remove %s", lockFile)
 	}

--- a/internal/workspace/lock.go
+++ b/internal/workspace/lock.go
@@ -46,6 +46,9 @@ func AcquireWorkspaceLock(lockFile string) (*os.File, error) {
 
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
+			if errors.Is(err, errLockReleased) {
+				return nil, fmt.Errorf("another grove operation is in progress; if this is wrong, remove %s", lockFile)
+			}
 			return nil, err
 		}
 		time.Sleep(min(lockPollInterval, remaining))

--- a/internal/workspace/lock.go
+++ b/internal/workspace/lock.go
@@ -12,7 +12,9 @@ import (
 )
 
 const (
-	maxLockRetries = 3
+	maxLockRetries   = 3
+	lockWaitTimeout  = 60 * time.Second
+	lockPollInterval = 200 * time.Millisecond
 	// lockMaxAge is the maximum age of a lock file before it's considered stale.
 	// This mitigates PID reuse attacks - if the lock is older than this duration,
 	// even if a process with the same PID is running, it's not the original holder.
@@ -23,10 +25,22 @@ const (
 // If a lock file exists, checks if the owning process is still running.
 // Stale locks (from crashed processes) are automatically removed.
 func AcquireWorkspaceLock(lockFile string) (*os.File, error) {
+	deadline := time.Now().Add(lockWaitTimeout)
 	for attempt := range maxLockRetries {
-		lockHandle, done, err := tryAcquireLock(lockFile, attempt)
-		if done {
-			return lockHandle, err
+		for {
+			lockHandle, done, err := tryAcquireLock(lockFile, attempt)
+			if done {
+				return lockHandle, err
+			}
+			if err == nil {
+				break
+			}
+
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				return nil, err
+			}
+			time.Sleep(min(lockPollInterval, remaining))
 		}
 	}
 	return nil, fmt.Errorf("failed to acquire lock after %d attempts; if no grove operation is running, remove %s", maxLockRetries, lockFile)
@@ -34,7 +48,8 @@ func AcquireWorkspaceLock(lockFile string) (*os.File, error) {
 
 // tryAcquireLock makes a single attempt to acquire the lock.
 // Returns (handle, true, nil) on success, (nil, true, err) on permanent failure,
-// or (nil, false, nil) if a stale lock was removed and retry is needed.
+// (nil, false, err) if a live process holds the lock, or (nil, false, nil) if a
+// stale lock was removed and retry is needed.
 func tryAcquireLock(lockFile string, attempt int) (*os.File, bool, error) {
 	lockHandle, err := os.OpenFile(lockFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600) //nolint:gosec // path derived from validated workspace
 	if err == nil {
@@ -85,5 +100,5 @@ func tryAcquireLock(lockFile string, attempt int) (*os.File, bool, error) {
 		return nil, false, nil // Retry regardless - if remove failed, next attempt will handle it
 	}
 
-	return nil, true, fmt.Errorf("another grove operation (PID %d) is in progress; if this is wrong, remove %s", pid, lockFile)
+	return nil, false, fmt.Errorf("another grove operation (PID %d) is in progress; if this is wrong, remove %s", pid, lockFile)
 }

--- a/internal/workspace/lock_test.go
+++ b/internal/workspace/lock_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sqve/grove/internal/fs"
 	"github.com/sqve/grove/internal/testutil"
@@ -32,7 +33,7 @@ func TestAcquireWorkspaceLock(t *testing.T) {
 		}
 	})
 
-	t.Run("fails when lock already held by running process", func(t *testing.T) {
+	t.Run("reports lock held by running process", func(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := testutil.TempDir(t)
@@ -48,11 +49,43 @@ func TestAcquireWorkspaceLock(t *testing.T) {
 			_ = os.Remove(lockFile)
 		}()
 
-		// Try to acquire second lock - should fail
-		_, err = AcquireWorkspaceLock(lockFile)
+		// Try to acquire second lock - should report contention
+		_, done, err := tryAcquireLock(lockFile, 0)
+		if done {
+			t.Error("expected live lock to be retried")
+		}
 		if err == nil {
 			t.Error("expected error when lock already held")
 		}
+	})
+
+	t.Run("waits for lock held by running process", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := testutil.TempDir(t)
+		lockFile := filepath.Join(tmpDir, ".grove-worktree.lock")
+
+		handle1, err := AcquireWorkspaceLock(lockFile)
+		if err != nil {
+			t.Fatalf("expected to acquire first lock, got error: %v", err)
+		}
+		released := make(chan struct{})
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			_ = handle1.Close()
+			_ = os.Remove(lockFile)
+			close(released)
+		}()
+
+		handle2, err := AcquireWorkspaceLock(lockFile)
+		<-released
+		if err != nil {
+			t.Fatalf("expected to acquire lock after release, got error: %v", err)
+		}
+		defer func() {
+			_ = handle2.Close()
+			_ = os.Remove(lockFile)
+		}()
 	})
 
 	t.Run("removes stale lock with invalid PID", func(t *testing.T) {

--- a/internal/workspace/lock_test.go
+++ b/internal/workspace/lock_test.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -223,4 +224,21 @@ func TestIsProcessRunning(t *testing.T) {
 			t.Error("expected non-existent PID to return false")
 		}
 	})
+}
+
+func TestTryAcquireLockRemovesNonPositivePID(t *testing.T) {
+	t.Parallel()
+	tmpDir := testutil.TempDir(t)
+	lockFile := filepath.Join(tmpDir, ".grove-worktree.lock")
+	if err := os.WriteFile(lockFile, []byte("0"), fs.FileStrict); err != nil {
+		t.Fatal(err)
+	}
+
+	_, done, err := tryAcquireLock(lockFile, 0)
+	if done || err != nil {
+		t.Fatalf("expected stale removal, got done=%v err=%v", done, err)
+	}
+	if _, statErr := os.Stat(lockFile); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected lock file removed, got %v", statErr)
+	}
 }


### PR DESCRIPTION
`grove add` now holds the workspace lock only while it mutates the git worktree registration, and a second grove operation waits for the lock instead of failing at once.

#### Changes

- `grove add` releases the workspace lock right after the worktree exists and auto-lock is applied, before preserve, link, and hook setup run. The deferred release in `runAdd` stays as an idempotent safety net.
- `AcquireWorkspaceLock` polls every 200ms while a live process holds the lock and gives up after 60s with the existing PID error. Both bounds are package constants; the configurable command timeout is deliberately not used, since it can be disabled to zero.
- A lock file that vanishes between the exclusive create and the staleness check is treated as a release and polled again. It no longer consumes a stale-removal attempt or aborts the wait.
- Stale-lock handling (dead PID, bad content, older than 30 minutes) keeps its bounded three-attempt removal. `grove move` inherits the waiting behavior through the shared function.
- Changelog entry under Fixed.

#### Test plan

- [x] Code review by Claude Opus 5 (cape:code-reviewer) on 7807bfa, findings addressed or dismissed
- [x] `make test`
- [x] `make build`
- [x] `go test ./internal/workspace/ -run TestAcquireWorkspaceLock -v`: contention test waits for a lock released after 500ms; stale-lock subtests unchanged
- [x] `go test -tags=integration ./cmd/grove -run TestScript/add_concurrent_hooks -count=3`: second add completes while the first add's hook is still running

---

Fixes ABU-277, AI-74