### PR TITLE
feat(list): add last_commit, --sort, and unknown filter errors

### DIFF
--- a/.changes/unreleased/added-list-last-commit.yaml
+++ b/.changes/unreleased/added-list-last-commit.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: "`grove list --json` now includes each worktree's last commit time, and `--filter` rejects unknown filter names."

--- a/.changes/unreleased/added-list-sort.yaml
+++ b/.changes/unreleased/added-list-sort.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: '`grove list --sort recent` now orders worktrees by their latest commit in table and JSON output.'

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ List all worktrees with status.
 - `--fast` — Skip remote sync checks
 - `--filter <status>` — Filter by: `dirty`, `ahead`, `behind`, `gone`, `locked`
 - `--json` — JSON output with a `last_commit` timestamp for each worktree
+- `--sort name|recent` — Sort by name or latest commit
 - `-v, --verbose` — Show paths and upstreams
 
 **Examples:**
@@ -262,6 +263,7 @@ grove list --fast
 grove list --filter dirty
 grove list --filter ahead,behind
 grove list --json
+grove list --sort recent
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ List all worktrees with status.
 - `--fast` — Skip remote sync checks
 - `--filter <status>` — Filter by: `dirty`, `ahead`, `behind`, `gone`, `locked`
 - `--json` — JSON output; includes `last_commit` when commit times are known (omitted with `--fast`)
-- `--sort name|recent` — Sort by name or latest commit
+- `--sort name|recent` — Sort by name or latest commit (`recent` needs commit times, so it cannot be combined with `--fast`)
 - `-v, --verbose` — Show paths and upstreams
 
 **Examples:**

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ List all worktrees with status.
 
 - `--fast` — Skip remote sync checks
 - `--filter <status>` — Filter by: `dirty`, `ahead`, `behind`, `gone`, `locked`
-- `--json` — JSON output
+- `--json` — JSON output with a `last_commit` timestamp for each worktree
 - `-v, --verbose` — Show paths and upstreams
 
 **Examples:**

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ List all worktrees with status.
 
 - `--fast` — Skip remote sync checks
 - `--filter <status>` — Filter by: `dirty`, `ahead`, `behind`, `gone`, `locked`
-- `--json` — JSON output with a `last_commit` timestamp for each worktree
+- `--json` — JSON output; includes `last_commit` when commit times are known (omitted with `--fast`)
 - `--sort name|recent` — Sort by name or latest commit
 - `-v, --verbose` — Show paths and upstreams
 

--- a/cmd/grove/commands/list.go
+++ b/cmd/grove/commands/list.go
@@ -56,7 +56,7 @@ Examples:
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show paths and upstream names")
 	cmd.Flags().StringVar(&filter, "filter", "", "Filter by status (valid: dirty, ahead, behind, gone, locked; comma-separated)")
-	cmd.Flags().StringVar(&sortBy, "sort", "name", "Sort by name or recent commit")
+	cmd.Flags().StringVar(&sortBy, "sort", "name", "Sort order (valid: name, recent)")
 	cmd.Flags().BoolP("help", "h", false, "Help for list")
 
 	_ = cmd.RegisterFlagCompletionFunc("filter", completeFilterValues)

--- a/cmd/grove/commands/list.go
+++ b/cmd/grove/commands/list.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/sqve/grove/internal/formatter"
@@ -15,6 +17,8 @@ import (
 	"github.com/sqve/grove/internal/logger"
 	"github.com/sqve/grove/internal/workspace"
 )
+
+var validFilters = []string{"dirty", "ahead", "behind", "gone", "locked"}
 
 // NewListCmd creates the list command
 func NewListCmd() *cobra.Command {
@@ -45,7 +49,7 @@ Examples:
 	cmd.Flags().BoolVar(&fast, "fast", false, "Skip sync status checks")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show paths and upstream names")
-	cmd.Flags().StringVar(&filter, "filter", "", "Filter by status: dirty,ahead,behind,gone,locked (comma-separated)")
+	cmd.Flags().StringVar(&filter, "filter", "", "Filter by status (valid: dirty, ahead, behind, gone, locked; comma-separated)")
 	cmd.Flags().BoolP("help", "h", false, "Help for list")
 
 	_ = cmd.RegisterFlagCompletionFunc("filter", completeFilterValues)
@@ -54,6 +58,11 @@ Examples:
 }
 
 func runList(fast, jsonOutput, verbose bool, filter string) error {
+	filters, err := parseFilters(filter)
+	if err != nil {
+		return err
+	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get current directory: %w", err)
@@ -74,7 +83,7 @@ func runList(fast, jsonOutput, verbose bool, filter string) error {
 	spin.Stop()
 
 	// Apply filter if specified
-	infos = filterWorktrees(infos, filter)
+	infos = filterWorktrees(infos, filters)
 
 	// Determine current worktree path (also works from subdirectories)
 	currentPath := ""
@@ -106,6 +115,7 @@ type worktreeJSON struct {
 	NoUpstream bool   `json:"no_upstream,omitempty"`
 	Locked     bool   `json:"locked,omitempty"`
 	LockReason string `json:"lock_reason,omitempty"`
+	LastCommit string `json:"last_commit,omitempty"`
 }
 
 func outputJSON(infos []*git.WorktreeInfo, currentPath string) error {
@@ -127,6 +137,9 @@ func outputJSON(infos []*git.WorktreeInfo, currentPath string) error {
 		}
 		if !info.Detached {
 			entry.Branch = info.Branch
+		}
+		if info.LastCommitTime != 0 {
+			entry.LastCommit = time.Unix(info.LastCommitTime, 0).UTC().Format(time.RFC3339)
 		}
 		output = append(output, entry)
 	}
@@ -197,8 +210,7 @@ func outputTable(infos []*git.WorktreeInfo, currentPath string, fast, verbose bo
 	return nil
 }
 
-func filterWorktrees(infos []*git.WorktreeInfo, filter string) []*git.WorktreeInfo {
-	filters := parseFilters(filter)
+func filterWorktrees(infos []*git.WorktreeInfo, filters []string) []*git.WorktreeInfo {
 	if len(filters) == 0 {
 		return infos
 	}
@@ -212,9 +224,9 @@ func filterWorktrees(infos []*git.WorktreeInfo, filter string) []*git.WorktreeIn
 	return filtered
 }
 
-func parseFilters(filter string) []string {
+func parseFilters(filter string) ([]string, error) {
 	if filter == "" {
-		return nil
+		return nil, nil
 	}
 
 	parts := strings.Split(filter, ",")
@@ -222,10 +234,13 @@ func parseFilters(filter string) []string {
 	for _, p := range parts {
 		p = strings.TrimSpace(strings.ToLower(p))
 		if p != "" {
+			if !slices.Contains(validFilters, p) {
+				return nil, fmt.Errorf("unknown filter %q (valid: %s)", p, strings.Join(validFilters, ", "))
+			}
 			filters = append(filters, p)
 		}
 	}
-	return filters
+	return filters, nil
 }
 
 func matchesAnyFilter(info *git.WorktreeInfo, filters []string) bool {
@@ -257,8 +272,6 @@ func matchesAnyFilter(info *git.WorktreeInfo, filters []string) bool {
 }
 
 func completeFilterValues(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	validFilters := []string{"dirty", "ahead", "behind", "gone", "locked"}
-
 	parts := strings.Split(toComplete, ",")
 	lastPart := parts[len(parts)-1]
 	prefix := ""

--- a/cmd/grove/commands/list.go
+++ b/cmd/grove/commands/list.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,7 +19,10 @@ import (
 	"github.com/sqve/grove/internal/workspace"
 )
 
-var validFilters = []string{"dirty", "ahead", "behind", "gone", "locked"}
+var (
+	validFilters = []string{"dirty", "ahead", "behind", "gone", "locked"}
+	validSorts   = []string{"name", "recent"}
+)
 
 // NewListCmd creates the list command
 func NewListCmd() *cobra.Command {
@@ -26,6 +30,7 @@ func NewListCmd() *cobra.Command {
 	var jsonOutput bool
 	var verbose bool
 	var filter string
+	var sortBy string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -36,13 +41,14 @@ Examples:
   grove list                  # Show all worktrees
   grove list --fast           # Skip remote sync checks
   grove list --filter dirty   # Show only dirty worktrees
+  grove list --sort recent    # Show most recently committed worktrees first
   grove list --verbose        # Include paths and upstreams`,
 		Args: cobra.NoArgs,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(fast, jsonOutput, verbose, filter)
+			return runList(fast, jsonOutput, verbose, filter, sortBy)
 		},
 	}
 
@@ -50,17 +56,25 @@ Examples:
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show paths and upstream names")
 	cmd.Flags().StringVar(&filter, "filter", "", "Filter by status (valid: dirty, ahead, behind, gone, locked; comma-separated)")
+	cmd.Flags().StringVar(&sortBy, "sort", "name", "Sort by name or recent commit")
 	cmd.Flags().BoolP("help", "h", false, "Help for list")
 
 	_ = cmd.RegisterFlagCompletionFunc("filter", completeFilterValues)
+	_ = cmd.RegisterFlagCompletionFunc("sort", cobra.FixedCompletions(validSorts, cobra.ShellCompDirectiveNoFileComp))
 
 	return cmd
 }
 
-func runList(fast, jsonOutput, verbose bool, filter string) error {
+func runList(fast, jsonOutput, verbose bool, filter, sortBy string) error {
 	filters, err := parseFilters(filter)
 	if err != nil {
 		return err
+	}
+	if !slices.Contains(validSorts, sortBy) {
+		return fmt.Errorf("unknown sort %q (valid: %s)", sortBy, strings.Join(validSorts, ", "))
+	}
+	if sortBy == "recent" && fast {
+		return errors.New("--sort recent cannot be used with --fast because recency requires commit times")
 	}
 
 	cwd, err := os.Getwd()
@@ -84,6 +98,11 @@ func runList(fast, jsonOutput, verbose bool, filter string) error {
 
 	// Apply filter if specified
 	infos = filterWorktrees(infos, filters)
+	if sortBy == "recent" {
+		sort.SliceStable(infos, func(i, j int) bool {
+			return infos[i].LastCommitTime > infos[j].LastCommitTime
+		})
+	}
 
 	// Determine current worktree path (also works from subdirectories)
 	currentPath := ""
@@ -98,7 +117,7 @@ func runList(fast, jsonOutput, verbose bool, filter string) error {
 		return outputJSON(infos, currentPath)
 	}
 
-	return outputTable(infos, currentPath, fast, verbose)
+	return outputTable(infos, currentPath, fast, verbose, sortBy)
 }
 
 type worktreeJSON struct {
@@ -149,17 +168,19 @@ func outputJSON(infos []*git.WorktreeInfo, currentPath string) error {
 	return enc.Encode(output)
 }
 
-func outputTable(infos []*git.WorktreeInfo, currentPath string, fast, verbose bool) error {
-	// Sort: current worktree first, then alphabetically by worktree name
-	sort.SliceStable(infos, func(i, j int) bool {
-		iCurrent := fs.PathsEqual(infos[i].Path, currentPath)
-		jCurrent := fs.PathsEqual(infos[j].Path, currentPath)
-		if iCurrent != jCurrent {
-			return iCurrent // Current worktree comes first
-		}
-		// Sort by worktree name (directory basename)
-		return filepath.Base(infos[i].Path) < filepath.Base(infos[j].Path)
-	})
+func outputTable(infos []*git.WorktreeInfo, currentPath string, fast, verbose bool, sortBy string) error {
+	if sortBy == "name" {
+		// Sort: current worktree first, then alphabetically by worktree name
+		sort.SliceStable(infos, func(i, j int) bool {
+			iCurrent := fs.PathsEqual(infos[i].Path, currentPath)
+			jCurrent := fs.PathsEqual(infos[j].Path, currentPath)
+			if iCurrent != jCurrent {
+				return iCurrent // Current worktree comes first
+			}
+			// Sort by worktree name (directory basename)
+			return filepath.Base(infos[i].Path) < filepath.Base(infos[j].Path)
+		})
+	}
 
 	// Calculate max widths for padding
 	maxNameLen := 0

--- a/cmd/grove/commands/list_test.go
+++ b/cmd/grove/commands/list_test.go
@@ -85,6 +85,17 @@ func TestParseFilters(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("returns error for unknown filter", func(t *testing.T) {
+		got, err := parseFilters("dirty,bogus")
+		if err == nil {
+			t.Fatalf("parseFilters(\"dirty,bogus\") = %v, want error", got)
+		}
+		want := `unknown filter "bogus" (valid: dirty, ahead, behind, gone, locked)`
+		if err.Error() != want {
+			t.Errorf("error = %q, want %q", err.Error(), want)
+		}
+	})
 }
 
 func TestMatchesAnyFilter(t *testing.T) {

--- a/cmd/grove/commands/list_test.go
+++ b/cmd/grove/commands/list_test.go
@@ -35,6 +35,9 @@ func TestNewListCmd(t *testing.T) {
 	if cmd.Flags().Lookup("filter") == nil {
 		t.Error("expected --filter flag")
 	}
+	if cmd.Flags().Lookup("sort") == nil {
+		t.Error("expected --sort flag")
+	}
 }
 
 func TestRunList(t *testing.T) {
@@ -45,7 +48,7 @@ func TestRunList(t *testing.T) {
 		tmpDir := testutil.TempDir(t)
 		testutil.Chdir(t, tmpDir)
 
-		err := runList(false, false, false, "")
+		err := runList(false, false, false, "", "name")
 		if err == nil {
 			t.Error("expected error for non-workspace directory")
 		}

--- a/cmd/grove/commands/list_test.go
+++ b/cmd/grove/commands/list_test.go
@@ -73,7 +73,10 @@ func TestParseFilters(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseFilters(tt.input)
+			got, err := parseFilters(tt.input)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if !reflect.DeepEqual(got, tt.expected) {
 				t.Errorf("parseFilters(%q) = %v, want %v", tt.input, got, tt.expected)
 			}
@@ -125,35 +128,35 @@ func TestFilterWorktrees(t *testing.T) {
 	}
 
 	t.Run("empty filter returns all", func(t *testing.T) {
-		got := filterWorktrees(infos, "")
+		got := filterWorktrees(infos, nil)
 		if len(got) != 4 {
 			t.Errorf("expected 4 worktrees, got %d", len(got))
 		}
 	})
 
 	t.Run("filter dirty", func(t *testing.T) {
-		got := filterWorktrees(infos, "dirty")
+		got := filterWorktrees(infos, []string{"dirty"})
 		if len(got) != 1 || got[0].Branch != "feature" {
 			t.Errorf("expected [feature], got %v", got)
 		}
 	})
 
 	t.Run("filter locked", func(t *testing.T) {
-		got := filterWorktrees(infos, "locked")
+		got := filterWorktrees(infos, []string{"locked"})
 		if len(got) != 1 || got[0].Branch != "main" {
 			t.Errorf("expected [main], got %v", got)
 		}
 	})
 
 	t.Run("filter gone", func(t *testing.T) {
-		got := filterWorktrees(infos, "gone")
+		got := filterWorktrees(infos, []string{"gone"})
 		if len(got) != 1 || got[0].Branch != "old" {
 			t.Errorf("expected [old], got %v", got)
 		}
 	})
 
 	t.Run("filter dirty,locked OR logic", func(t *testing.T) {
-		got := filterWorktrees(infos, "dirty,locked")
+		got := filterWorktrees(infos, []string{"dirty", "locked"})
 		if len(got) != 2 {
 			t.Errorf("expected 2 worktrees, got %d", len(got))
 		}

--- a/cmd/grove/testdata/script/list_filter_invalid.txt
+++ b/cmd/grove/testdata/script/list_filter_invalid.txt
@@ -1,6 +1,4 @@
-# Test: grove list --filter with unknown value matches nothing
-setup_workspace
-
-exec grove list --filter invalid --plain
-! stdout 'main'
-stderr 'Gathering worktree status'
+# Test: grove list --filter rejects unknown values before listing
+! exec grove list --filter bogus --plain
+stderr '^Error: unknown filter "bogus" \(valid: dirty, ahead, behind, gone, locked\)$'
+! stdout .

--- a/cmd/grove/testdata/script/list_json_last_commit.txt
+++ b/cmd/grove/testdata/script/list_json_last_commit.txt
@@ -1,0 +1,5 @@
+# Test: grove list --json includes the last commit time in RFC3339 UTC
+setup_workspace
+
+exec grove list --json
+stdout '"last_commit": "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"'

--- a/cmd/grove/testdata/script/list_sort_errors.txt
+++ b/cmd/grove/testdata/script/list_sort_errors.txt
@@ -1,0 +1,16 @@
+# Test: grove list validates --sort before gathering worktree status
+setup_workspace
+
+! exec grove list --sort recent --fast --plain
+stderr '^Error: --sort recent cannot be used with --fast because recency requires commit times$'
+! stderr 'Gathering worktree status'
+! stdout .
+
+! exec grove list --sort bogus --plain
+stderr '^Error: unknown sort "bogus" \(valid: name, recent\)$'
+! stderr 'Gathering worktree status'
+! stdout .
+
+exec grove __complete list --sort ''
+stdout '^name$'
+stdout '^recent$'

--- a/cmd/grove/testdata/script/list_sort_recent.txt
+++ b/cmd/grove/testdata/script/list_sort_recent.txt
@@ -1,0 +1,38 @@
+# Test: grove list --sort recent orders table and JSON by commit time
+setup_workspace alpha zulu
+
+exec grove add alpha
+exec grove add zulu
+exec sh -c 'cd ../alpha && GIT_COMMITTER_DATE="2040-01-01T00:00:00Z" GIT_AUTHOR_DATE="2040-01-01T00:00:00Z" git commit --allow-empty -m newest'
+exec sh -c 'cd ../zulu && GIT_COMMITTER_DATE="2030-01-01T00:00:00Z" GIT_AUTHOR_DATE="2030-01-01T00:00:00Z" git commit --allow-empty -m newer'
+
+# Default table order remains current first, then basename.
+exec grove list --plain
+cmp stdout $WORK/default-table.txt
+
+# Default JSON order remains branch-name order.
+exec sh -c 'grove list --json | grep name'
+cmp stdout $WORK/default-json.txt
+
+# Recent order ignores the current worktree in both formats.
+exec grove list --sort recent --plain
+cmp stdout $WORK/recent.txt
+exec sh -c 'grove list --sort recent --json | grep name'
+cmp stdout $WORK/recent-json.txt
+
+-- default-table.txt --
+* main  [main]  [locked] =
+  alpha [alpha] +1
+  zulu  [zulu]  +1
+-- default-json.txt --
+    "name": "alpha",
+    "name": "main",
+    "name": "zulu",
+-- recent.txt --
+  alpha [alpha] +1
+  zulu  [zulu]  +1
+* main  [main]  [locked] =
+-- recent-json.txt --
+    "name": "alpha",
+    "name": "zulu",
+    "name": "main",

--- a/cmd/grove/testdata/script/list_sort_recent.txt
+++ b/cmd/grove/testdata/script/list_sort_recent.txt
@@ -8,7 +8,7 @@ exec sh -c 'cd ../zulu && GIT_COMMITTER_DATE="2030-01-01T00:00:00Z" GIT_AUTHOR_D
 
 # Default table order remains current first, then basename.
 exec grove list --plain
-cmp stdout $WORK/default-table.txt
+stdout '(?s)^\* main .*\n  alpha .*\n  zulu '
 
 # Default JSON order remains branch-name order.
 exec grove list --json
@@ -16,15 +16,6 @@ stdout '(?s)"name": "alpha".*"name": "main".*"name": "zulu"'
 
 # Recent order ignores the current worktree in both formats.
 exec grove list --sort recent --plain
-cmp stdout $WORK/recent.txt
+stdout '(?s)^  alpha .*\n  zulu .*\n\* main '
 exec grove list --sort recent --json
 stdout '(?s)"name": "alpha".*"name": "zulu".*"name": "main"'
-
--- default-table.txt --
-* main  [main]  [locked] =
-  alpha [alpha] +1
-  zulu  [zulu]  +1
--- recent.txt --
-  alpha [alpha] +1
-  zulu  [zulu]  +1
-* main  [main]  [locked] =

--- a/cmd/grove/testdata/script/list_sort_recent.txt
+++ b/cmd/grove/testdata/script/list_sort_recent.txt
@@ -11,28 +11,20 @@ exec grove list --plain
 cmp stdout $WORK/default-table.txt
 
 # Default JSON order remains branch-name order.
-exec sh -c 'grove list --json | grep name'
-cmp stdout $WORK/default-json.txt
+exec grove list --json
+stdout '(?s)"name": "alpha".*"name": "main".*"name": "zulu"'
 
 # Recent order ignores the current worktree in both formats.
 exec grove list --sort recent --plain
 cmp stdout $WORK/recent.txt
-exec sh -c 'grove list --sort recent --json | grep name'
-cmp stdout $WORK/recent-json.txt
+exec grove list --sort recent --json
+stdout '(?s)"name": "alpha".*"name": "zulu".*"name": "main"'
 
 -- default-table.txt --
 * main  [main]  [locked] =
   alpha [alpha] +1
   zulu  [zulu]  +1
--- default-json.txt --
-    "name": "alpha",
-    "name": "main",
-    "name": "zulu",
 -- recent.txt --
   alpha [alpha] +1
   zulu  [zulu]  +1
 * main  [main]  [locked] =
--- recent-json.txt --
-    "name": "alpha",
-    "name": "zulu",
-    "name": "main",


### PR DESCRIPTION
`grove list` now exposes each worktree's last commit time in JSON, can order worktrees by recency with `--sort recent`, and rejects unknown `--filter` values instead of silently returning nothing.

#### Changes

- `grove list --json` includes `last_commit` as an RFC3339 UTC timestamp for every worktree with a readable HEAD. The field is omitted when the time is unknown or when `--fast` skips commit lookups. The timestamp comes from the commit time the command already collects, so no extra git calls are made.
- New `--sort name|recent` flag. `name` is the default and leaves both existing orderings untouched: JSON stays branch-name ordered and the table stays current-worktree-first then by basename. `recent` orders rows by last commit time descending in both table and JSON, and no longer forces the current worktree first. Worktrees with an unknown commit time sort last. Shell completion is registered for the flag.
- `--sort recent --fast` exits 1 with an error explaining that recency needs commit times, which fast mode skips. Any other `--sort` value exits 1 naming the valid values.
- `--filter bogus` exits 1 with `unknown filter "bogus" (valid: dirty, ahead, behind, gone, locked)` and prints no listing. Validation runs before the spinner starts. The valid names live in one package-level list shared by validation and shell completion; the filter matching switch is unchanged.
- README `grove list` section documents `--sort` and the `last_commit` field; the `--filter` and `--sort` help strings name their valid values; two changelog entries added under `.changes/unreleased`.

#### Test plan

- [x] Code review by Claude Opus 5 (cape:code-reviewer) on 7f5fef1, findings addressed or dismissed
- [x] `go test -tags=integration ./cmd/grove -run 'TestScript/(list_json_last_commit|list_filter_invalid|list_sort_recent|list_sort_errors)$' -count=1`
- [x] `make test`
- [x] `make test-integration`
- [x] `grove list --filter bogus` exits 1 with the valid-values hint and no listing
- [x] `grove list --sort recent --fast` exits 1
- [x] `grove list --json` shows `last_commit`; `grove list --json --fast` omits it

#### Verification performed

- New script tests cover R1 (`last_commit` present and RFC3339), R2 (two worktrees at different commit times ordered by `--sort recent` in table and JSON, default output unchanged), R3 (unknown filter error and exit code), and R4 (`--sort recent --fast` and invalid `--sort` exit 1). All pass on HEAD.
- Full unit suite (1243 tests) and integration suite (773 tests) pass; `go vet` and `gofmt` are clean.
- Ran the built binary against this workspace: `--filter bogus` and `--sort recent --fast` exit 1 with the expected messages; `--json` carries `last_commit` and `--json --fast` omits it.
- `make lint` fails on the untouched main commit as well (golangci-lint 2.8.0 built with Go 1.25 against a Go 1.27 toolchain), so it was not used as a gate locally; CI runs its own lint.

---

Fixes ABU-265, AI-48