### PR TITLE
Release v1.9.1

### DIFF
--- a/.changes/unreleased/fixed-add-lock-before-hooks.yaml
+++ b/.changes/unreleased/fixed-add-lock-before-hooks.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: '`grove add` now releases the workspace lock before running hooks, and lock contention waits up to 60 seconds for the other operation instead of failing immediately.'
-time: 2026-09-03T11:50:40.490062568+02:00

--- a/.changes/unreleased/fixed-spinner-non-tty.yaml
+++ b/.changes/unreleased/fixed-spinner-non-tty.yaml
@@ -1,2 +1,0 @@
-kind: Fixed
-body: 'Spinners now print a single plain `→ message` line instead of animating when stderr is not a terminal, so piped and CI output no longer contains cursor-control sequences. `--plain` still takes precedence.'

--- a/.changes/v1.9.1.md
+++ b/.changes/v1.9.1.md
@@ -1,0 +1,5 @@
+## [v1.9.1](https://github.com/sQVe/grove/releases/tag/v1.9.1) - 2026-09-03
+
+### Fixed
+- Spinners now print a single plain `→ message` line instead of animating when stderr is not a terminal, so piped and CI output no longer contains cursor-control sequences. `--plain` still takes precedence.
+- `grove add` now releases the workspace lock before running hooks, and lock contention waits up to 60 seconds for the other operation instead of failing immediately.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v1.9.1](https://github.com/sQVe/grove/releases/tag/v1.9.1) - 2026-09-03
+
+### Fixed
+- Spinners now print a single plain `→ message` line instead of animating when stderr is not a terminal, so piped and CI output no longer contains cursor-control sequences. `--plain` still takes precedence.
+- `grove add` now releases the workspace lock before running hooks, and lock contention waits up to 60 seconds for the other operation instead of failing immediately.
+
 ## [v1.9.0](https://github.com/sQVe/grove/releases/tag/v1.9.0) - 2026-07-01
 
 ### Changed


### PR DESCRIPTION
This PR was created by the [Changie release GitHub action](https://github.com/labd/changie-release-action). When you're ready to do a release, you can merge this and the tag v1.9.1 will be created.  If you're not ready to do a release yet, that's fine, whenever you add more changes to main, this PR will be updated.

# Releases
## [v1.9.1](https://github.com/sQVe/grove/releases/tag/v1.9.1) - 2026-09-03

### Fixed
- Spinners now print a single plain `→ message` line instead of animating when stderr is not a terminal, so piped and CI output no longer contains cursor-control sequences. `--plain` still takes precedence.
- `grove add` now releases the workspace lock before running hooks, and lock contention waits up to 60 seconds for the other operation instead of failing immediately.