### PR TITLE
fix(git): resolve the default branch from origin/HEAD (AI-134)

### DIFF
--- a/.changes/unreleased/fixed-IZebvGcN.yaml
+++ b/.changes/unreleased/fixed-IZebvGcN.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Resolve the default branch from origin/HEAD before bare HEAD, main, and master, checking existing local refs without network access (AI-134).
+time: 2026-09-07T14:29:34.057077769+02:00
+custom:
+  Issue: ''

--- a/cmd/grove/commands/list.go
+++ b/cmd/grove/commands/list.go
@@ -19,10 +19,13 @@ import (
 	"github.com/sqve/grove/internal/workspace"
 )
 
-const sortRecent = "recent"
+const (
+	sortRecent   = "recent"
+	filterLocked = "locked"
+)
 
 var (
-	validFilters = []string{"dirty", "ahead", "behind", "gone", "locked"}
+	validFilters = []string{"dirty", "ahead", "behind", "gone", filterLocked}
 	validSorts   = []string{"name", sortRecent}
 )
 
@@ -80,7 +83,7 @@ func runList(fast, jsonOutput, verbose bool, filter, sortBy string) error {
 	}
 	if fast {
 		for _, f := range filters {
-			if f != "locked" {
+			if f != filterLocked {
 				return fmt.Errorf("--filter %s cannot be used with --fast because status checks are skipped", f)
 			}
 		}
@@ -291,7 +294,7 @@ func matchesAnyFilter(info *git.WorktreeInfo, filters []string) bool {
 			if info.Gone {
 				return true
 			}
-		case "locked":
+		case filterLocked:
 			if info.Locked {
 				return true
 			}

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -196,30 +196,45 @@ func GetDefaultBranch(bareDir string) (string, error) {
 	cancel()
 	if err == nil {
 		if branch, ok := strings.CutPrefix(strings.TrimSpace(string(output)), "refs/remotes/origin/"); ok {
-			if exists, _ := RemoteBranchExists(bareDir, "origin", branch); exists {
+			exists, existsErr := RemoteBranchExists(bareDir, "origin", branch)
+			if existsErr != nil {
+				return "", fmt.Errorf("failed to check origin/%s: %w", branch, existsErr)
+			}
+			if exists {
 				return branch, nil
 			}
 		}
 	}
 
 	headFile := filepath.Join(bareDir, "HEAD")
-	content, readErr := os.ReadFile(headFile) // nolint:gosec // Reading git HEAD file
-	branch, _ := strings.CutPrefix(strings.TrimSpace(string(content)), "ref: refs/heads/")
-	for _, candidate := range []string{branch, "main", "master"} {
-		if candidate == "" {
-			continue
+	content, err := os.ReadFile(headFile) // nolint:gosec // Reading git HEAD file
+	if err != nil {
+		return "", fmt.Errorf("failed to read HEAD: %w", err)
+	}
+
+	candidates := []string{"main", "master"}
+	if branch, ok := strings.CutPrefix(strings.TrimSpace(string(content)), "ref: refs/heads/"); ok {
+		candidates = append([]string{branch}, candidates...)
+	}
+
+	for _, candidate := range candidates {
+		exists, existsErr := LocalBranchExists(bareDir, candidate)
+		if existsErr != nil {
+			return "", fmt.Errorf("failed to check branch %s: %w", candidate, existsErr)
 		}
-		if exists, _ := LocalBranchExists(bareDir, candidate); exists {
+		if exists {
 			return candidate, nil
 		}
-		if exists, _ := RemoteBranchExists(bareDir, "origin", candidate); exists {
+
+		exists, existsErr = RemoteBranchExists(bareDir, "origin", candidate)
+		if existsErr != nil {
+			return "", fmt.Errorf("failed to check origin/%s: %w", candidate, existsErr)
+		}
+		if exists {
 			return candidate, nil
 		}
 	}
 
-	if readErr != nil {
-		return "", fmt.Errorf("failed to read HEAD: %w", readErr)
-	}
 	return "", fmt.Errorf("could not determine default branch from HEAD")
 }
 

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -184,25 +184,42 @@ func GetCurrentBranchOrDetached(path string) (branch string, detached bool, err 
 	return strings.TrimSpace(string(output)), true, nil
 }
 
-// GetDefaultBranch returns the default branch for a bare repository
+// GetDefaultBranch resolves origin/HEAD, bare HEAD, main, then master using only local ref reads.
 func GetDefaultBranch(bareDir string) (string, error) {
 	if bareDir == "" {
 		return "", errors.New("repository path cannot be empty")
 	}
 
+	cmd, cancel := GitCommand("git", "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD")
+	cmd.Dir = bareDir
+	output, err := cmd.Output()
+	cancel()
+	if err == nil {
+		if branch, ok := strings.CutPrefix(strings.TrimSpace(string(output)), "refs/remotes/origin/"); ok {
+			if exists, _ := RemoteBranchExists(bareDir, "origin", branch); exists {
+				return branch, nil
+			}
+		}
+	}
+
 	headFile := filepath.Join(bareDir, "HEAD")
-
-	content, err := os.ReadFile(headFile) // nolint:gosec // Reading git HEAD file
-	if err != nil {
-		return "", fmt.Errorf("failed to read HEAD: %w", err)
+	content, readErr := os.ReadFile(headFile) // nolint:gosec // Reading git HEAD file
+	branch, _ := strings.CutPrefix(strings.TrimSpace(string(content)), "ref: refs/heads/")
+	for _, candidate := range []string{branch, "main", "master"} {
+		if candidate == "" {
+			continue
+		}
+		if exists, _ := LocalBranchExists(bareDir, candidate); exists {
+			return candidate, nil
+		}
+		if exists, _ := RemoteBranchExists(bareDir, "origin", candidate); exists {
+			return candidate, nil
+		}
 	}
 
-	line := strings.TrimSpace(string(content))
-
-	if after, ok := strings.CutPrefix(line, "ref: refs/heads/"); ok {
-		return after, nil
+	if readErr != nil {
+		return "", fmt.Errorf("failed to read HEAD: %w", readErr)
 	}
-
 	return "", fmt.Errorf("could not determine default branch from HEAD")
 }
 

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -533,56 +533,76 @@ func TestDeleteBranch(t *testing.T) {
 }
 
 func TestGetDefaultBranch(t *testing.T) {
-	t.Run("returns main for bare repo with main branch", func(t *testing.T) {
-		tempDir := testutil.TempDir(t)
-		bareDir := filepath.Join(tempDir, "test.bare")
-		if err := os.MkdirAll(bareDir, fs.DirStrict); err != nil {
-			t.Fatalf("failed to create bare directory: %v", err)
-		}
+	tests := []struct {
+		name       string
+		originHead string
+		head       string
+		refs       []string
+		want       string
+	}{
+		{name: "origin HEAD takes precedence", originHead: "develop", head: "feature", refs: []string{"remotes/origin/develop", "heads/feature", "heads/main"}, want: "develop"},
+		{name: "valid bare HEAD", head: "feature", refs: []string{"heads/feature", "heads/main"}, want: "feature"},
+		{name: "dangling bare HEAD falls back to main", head: "missing", refs: []string{"heads/main", "heads/master"}, want: "main"},
+		{name: "master fallback", head: "missing", refs: []string{"heads/master"}, want: "master"},
+		{name: "remote main fallback", head: "missing", refs: []string{"remotes/origin/main"}, want: "main"},
+		{name: "remote master fallback", head: "missing", refs: []string{"remotes/origin/master"}, want: "master"},
+		{name: "bare HEAD target exists remotely", head: "feature", refs: []string{"remotes/origin/feature", "heads/main"}, want: "feature"},
+		{name: "dangling origin HEAD", originHead: "missing", head: "feature", refs: []string{"heads/feature"}, want: "feature"},
+		{name: "nothing resolvable", originHead: "missing", head: "missing"},
+		{name: "unrelated branch is not a default", head: "missing", refs: []string{"heads/other"}},
+		{name: "tags are not branches", originHead: "release", head: "release", refs: []string{"tags/release", "tags/main", "tags/master"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := testgit.NewTestRepo(t)
+			bareDir := filepath.Join(repo.TempDir, "test.bare")
+			// Clone from disk to create a real bare repository.
+			repo.RunOutput("clone", "--bare", "--local", repo.Path, bareDir)
+			hash := strings.TrimSpace(repo.RunOutput("rev-parse", "HEAD"))
+			repo.RunOutput("--git-dir", bareDir, "update-ref", "-d", "refs/heads/main")
+			for _, ref := range tt.refs {
+				repo.RunOutput("--git-dir", bareDir, "update-ref", "refs/"+ref, hash)
+			}
+			repo.RunOutput("--git-dir", bareDir, "symbolic-ref", "HEAD", "refs/heads/"+tt.head)
+			if tt.originHead != "" {
+				repo.RunOutput("--git-dir", bareDir, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/"+tt.originHead)
+			}
+			repo.RunOutput("--git-dir", bareDir, "pack-refs", "--all")
+			refsBefore := repo.RunOutput("--git-dir", bareDir, "for-each-ref", "--format=%(refname) %(objectname) %(symref)")
 
-		// Initialize bare repo with main branch
-		cmd := exec.Command("git", "init", "--bare", "-b", "main") //nolint:gosec
-		cmd.Dir = bareDir
-		if err := cmd.Run(); err != nil {
-			t.Fatalf("failed to init bare repo: %v", err)
-		}
-
-		branch, err := GetDefaultBranch(bareDir)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if branch != "main" {
-			t.Errorf("expected 'main', got %q", branch)
-		}
-	})
-
-	t.Run("returns master for bare repo with master branch", func(t *testing.T) {
-		tempDir := testutil.TempDir(t)
-		bareDir := filepath.Join(tempDir, "test.bare")
-		if err := os.MkdirAll(bareDir, fs.DirStrict); err != nil {
-			t.Fatalf("failed to create bare directory: %v", err)
-		}
-
-		// Initialize bare repo with master branch
-		cmd := exec.Command("git", "init", "--bare", "-b", "master") //nolint:gosec
-		cmd.Dir = bareDir
-		if err := cmd.Run(); err != nil {
-			t.Fatalf("failed to init bare repo: %v", err)
-		}
-
-		branch, err := GetDefaultBranch(bareDir)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if branch != "master" {
-			t.Errorf("expected 'master', got %q", branch)
-		}
-	})
+			// Disable all Git transports during resolution.
+			t.Setenv("GIT_ALLOW_PROTOCOL", "")
+			branch, err := GetDefaultBranch(bareDir)
+			if tt.want == "" {
+				if err == nil || err.Error() != "could not determine default branch from HEAD" {
+					t.Errorf("expected unresolved default branch error, got %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if branch != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, branch)
+			}
+			if got := strings.TrimSpace(repo.RunOutput("--git-dir", bareDir, "symbolic-ref", "HEAD")); got != "refs/heads/"+tt.head {
+				t.Errorf("HEAD changed to %q", got)
+			}
+			if got := repo.RunOutput("--git-dir", bareDir, "for-each-ref", "--format=%(refname) %(objectname) %(symref)"); got != refsBefore {
+				t.Errorf("refs changed during resolution")
+			}
+		})
+	}
 
 	t.Run("returns error for empty path", func(t *testing.T) {
 		_, err := GetDefaultBranch("")
-		if err == nil {
-			t.Error("expected error for empty path")
+		if err == nil || err.Error() != "repository path cannot be empty" {
+			t.Errorf("expected empty path error, got %v", err)
+		}
+	})
+
+	t.Run("returns error for missing HEAD", func(t *testing.T) {
+		_, err := GetDefaultBranch(testutil.TempDir(t))
+		if err == nil || !strings.Contains(err.Error(), "failed to read HEAD:") {
+			t.Errorf("expected HEAD read error, got %v", err)
 		}
 	})
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -704,52 +704,10 @@ func TestResolveConfigDir(t *testing.T) {
 	t.Run("returns default branch worktree from workspace root", func(t *testing.T) {
 		t.Parallel()
 
-		workspaceDir := testutil.TempDir(t)
-		bareDir := filepath.Join(workspaceDir, ".bare")
+		w := testgit.NewGroveWorkspace(t, "main", "alpha")
+		mainWorktree := w.WorktreePath("main")
 
-		// Create bare repo with HEAD pointing to main
-		if err := os.MkdirAll(bareDir, fs.DirGit); err != nil {
-			t.Fatal(err)
-		}
-		cmd := exec.Command("git", "init", "--bare")
-		cmd.Dir = bareDir
-		if err := cmd.Run(); err != nil {
-			t.Fatal(err)
-		}
-		// HEAD file should already point to refs/heads/main by default
-
-		// Create main worktree directory
-		mainWorktree := filepath.Join(workspaceDir, "main")
-		if err := os.MkdirAll(mainWorktree, fs.DirGit); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(mainWorktree, ".git"), []byte("gitdir: ../.bare/worktrees/main"), fs.FileStrict); err != nil {
-			t.Fatal(err)
-		}
-
-		// Create another worktree (alphabetically first)
-		alphaWorktree := filepath.Join(workspaceDir, "alpha")
-		if err := os.MkdirAll(alphaWorktree, fs.DirGit); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(alphaWorktree, ".git"), []byte("gitdir: ../.bare/worktrees/alpha"), fs.FileStrict); err != nil {
-			t.Fatal(err)
-		}
-
-		// Register worktrees with git (create worktree metadata)
-		worktreesDir := filepath.Join(bareDir, "worktrees")
-		for _, name := range []string{"main", "alpha"} {
-			wtDir := filepath.Join(worktreesDir, name)
-			if err := os.MkdirAll(wtDir, fs.DirGit); err != nil {
-				t.Fatal(err)
-			}
-			gitdirPath := filepath.Join(workspaceDir, name)
-			if err := os.WriteFile(filepath.Join(wtDir, "gitdir"), []byte(gitdirPath), fs.FileStrict); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		result, err := ResolveConfigDir(workspaceDir)
+		result, err := ResolveConfigDir(w.Dir)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
## What

`GetDefaultBranch` read `.bare/HEAD` and trusted it. `init convert` freezes that value, and deleting the branch it points at leaves it dangling, so callers resolved a default branch that was stale or did not exist at all.

It now resolves through a chain, stopping at the first branch that actually exists: `refs/remotes/origin/HEAD`, then `.bare/HEAD`, then `main`, then `master`.

Every rung verifies existence with `git show-ref` before returning, so the function can no longer hand back a branch name that does not resolve. Resolution is offline: `git symbolic-ref` and `git show-ref` only, no fetch, no `ls-remote`, no writes.

## Changes

- `internal/git/branch.go`: `GetDefaultBranch` gains the origin/HEAD -> bare HEAD -> main -> master chain, each rung existence-checked. The exported signature is unchanged, so callers are fixed for free, including `findFallbackSourceWorktree` and `findConfigWorktree` in `add.go`, which picked the wrong source worktree for file preservation in converted workspaces.
- `internal/git/branch_test.go`: table test over real bare clones covering every rung.
- `internal/workspace/workspace_test.go`: fixtures use real refs instead of empty ones, now that resolution verifies existence.
- `cmd/grove/commands/list.go`: extracts a `filterLocked` constant. Pre-existing `goconst` lint debt that blocked CI on this branch, not part of the resolution change.

## Test plan

- [x] `TestGetDefaultBranch` — 11 table cases over real bare clones: `origin/HEAD` present, `origin/HEAD` dangling, valid `.bare/HEAD`, dangling `.bare/HEAD` falling through to `main` and to `master`, remote-only fallbacks, tags rejected as branches, and nothing resolvable.
- [x] Each case asserts `HEAD` and the full ref list are byte-identical after resolution, so no repository state is touched.
- [x] Transports disabled during resolution via `GIT_ALLOW_PROTOCOL=""`, proving the offline requirement.
- [x] `make ci` green, 789 integration tests.
- [x] Code review by claude opus 5 (cape:code-reviewer) on 190ca131d10bad9b15572b40e7b243df3e88ad7d, findings addressed or dismissed.

## Known limitation

The chain can return a branch that exists only as `refs/remotes/origin/<name>`, which callers such as `prune --merged` cannot resolve as a rev. That is what R1 asks for — `origin/HEAD` names the default branch even when no local ref exists — and it is not a regression, since the old code could return a fully deleted branch and broke the same callers harder. Tracked with the rest of the epic.

## Deferred verification

None.

## Scope

Closes AI-134 only. Epic AI-131 stays open: R4, R5, and R6 cover the `grove doctor` check that reports and repairs a wrong bare HEAD, landing as a separate task on the existing doctor `Issue`/`AutoFixable` machinery.

Part of AI-131 / ABU-317.