### PR TITLE
fix(link): match nested paths in link patterns

### DIFF
--- a/.changes/unreleased/fixed-KvecqMyt.yaml
+++ b/.changes/unreleased/fixed-KvecqMyt.yaml
@@ -1,5 +1,5 @@
 kind: Fixed
-body: Link nested directories matched by path patterns such as apps/*/node_modules with resolving relative symlinks.
+body: Link nested directories matched by path patterns such as apps/*/node_modules, using relative symlinks so the links resolve.
 time: 2026-09-07T14:30:31.952371956+02:00
 custom:
   Issue: ''

--- a/.changes/unreleased/fixed-KvecqMyt.yaml
+++ b/.changes/unreleased/fixed-KvecqMyt.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Link nested directories matched by path patterns such as apps/*/node_modules with resolving relative symlinks.
+time: 2026-09-07T14:30:31.952371956+02:00
+custom:
+  Issue: ''

--- a/README.md
+++ b/README.md
@@ -588,7 +588,8 @@ directories = []
 [link]
 # Directories to symlink from the source worktree when creating a new one.
 # Useful for sharing tool state (e.g., .claude) across worktrees.
-# Matched against directory names in the worktree root.
+# Patterns without / match directory names in the worktree root.
+# Patterns with / match paths relative to the worktree root.
 # Creates relative symlinks so the workspace remains portable.
 patterns = []
 
@@ -641,11 +642,18 @@ add = ["lefthook install"]
 
 ### Next.js shared build caches
 
-Next.js build output (`.next`) and Turborepo cache (`.turbo`) can be shared across worktrees to avoid redundant rebuilds. Never symlink `node_modules/` — it contains absolute paths and branch-specific dependency versions.
+Next.js build output (`.next`) and Turborepo cache (`.turbo`) can be shared across worktrees to avoid redundant rebuilds. Avoid symlinking `node_modules/` unless its contents are portable and dependency versions match across worktrees. It can contain absolute paths and branch-specific dependency versions.
 
 ```toml
 [link]
 patterns = [".next", ".turbo"]
+```
+
+For a monorepo that meets those conditions, use a path pattern to link each app's dependencies:
+
+```toml
+[link]
+patterns = ["apps/*/node_modules"]
 ```
 
 ### Rust shared target directory

--- a/cmd/grove/commands/list.go
+++ b/cmd/grove/commands/list.go
@@ -19,10 +19,13 @@ import (
 	"github.com/sqve/grove/internal/workspace"
 )
 
-const sortRecent = "recent"
+const (
+	sortRecent   = "recent"
+	filterLocked = "locked"
+)
 
 var (
-	validFilters = []string{"dirty", "ahead", "behind", "gone", "locked"}
+	validFilters = []string{"dirty", "ahead", "behind", "gone", filterLocked}
 	validSorts   = []string{"name", sortRecent}
 )
 
@@ -80,7 +83,7 @@ func runList(fast, jsonOutput, verbose bool, filter, sortBy string) error {
 	}
 	if fast {
 		for _, f := range filters {
-			if f != "locked" {
+			if f != filterLocked {
 				return fmt.Errorf("--filter %s cannot be used with --fast because status checks are skipped", f)
 			}
 		}
@@ -291,7 +294,7 @@ func matchesAnyFilter(info *git.WorktreeInfo, filters []string) bool {
 			if info.Gone {
 				return true
 			}
-		case "locked":
+		case filterLocked:
 			if info.Locked {
 				return true
 			}

--- a/internal/config/grove.template.toml
+++ b/internal/config/grove.template.toml
@@ -57,7 +57,8 @@ directories = []
 [link]
 # Directories to symlink from the source worktree when creating a new one.
 # Useful for sharing tool state across worktrees.
-# Matched against directory names in the worktree root.
+# Patterns without / match directory names in the worktree root.
+# Patterns with / match paths relative to the worktree root, e.g. apps/*/node_modules.
 # Creates relative symlinks so the workspace remains portable.
 patterns = []
 

--- a/internal/workspace/link.go
+++ b/internal/workspace/link.go
@@ -3,7 +3,9 @@ package workspace
 import (
 	"errors"
 	"fmt"
+	iofs "io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -62,18 +64,17 @@ func LinkDirectoriesToWorktree(sourceDir, destDir string, patterns []string) (*L
 			logger.Debug("Skipping invalid link pattern (path traversal): %s", pattern)
 			continue
 		}
-		matches, err := filepath.Glob(filepath.Join(sourceDir, filepath.FromSlash(pattern)))
+		// Glob within the source worktree so glob characters in its own path are
+		// never read as pattern syntax, and no match can escape it.
+		matches, err := iofs.Glob(os.DirFS(sourceDir), path.Clean(pattern))
 		if err != nil {
 			continue
 		}
-		for _, sourcePath := range matches {
-			info, err := os.Stat(sourcePath)
+		for _, match := range matches {
+			name := filepath.FromSlash(match)
+			info, err := os.Stat(filepath.Join(sourceDir, name))
 			if err != nil || !info.IsDir() {
 				continue
-			}
-			name, err := filepath.Rel(sourceDir, sourcePath)
-			if err != nil {
-				return result, err
 			}
 			names = append(names, name)
 		}
@@ -99,6 +100,10 @@ linkLoop:
 			parent = filepath.Join(parent, part)
 			if info, err := os.Lstat(parent); err == nil {
 				if info.Mode()&os.ModeSymlink != 0 {
+					continue linkLoop
+				}
+				if !info.IsDir() {
+					result.Conflicts = append(result.Conflicts, name)
 					continue linkLoop
 				}
 			} else if !errors.Is(err, os.ErrNotExist) {

--- a/internal/workspace/link.go
+++ b/internal/workspace/link.go
@@ -126,8 +126,11 @@ linkLoop:
 			return result, err
 		}
 
+		// Windows reports a file in the parent chain as not-exist rather than ENOTDIR,
+		// so the Lstat checks above miss it and this is where that case surfaces.
 		if err := os.MkdirAll(filepath.Dir(destPath), fs.DirGit); err != nil {
-			return result, err
+			result.Conflicts = append(result.Conflicts, name)
+			continue
 		}
 
 		if err := os.Symlink(relTarget, destPath); err != nil {

--- a/internal/workspace/link.go
+++ b/internal/workspace/link.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/sqve/grove/internal/fs"
+	"github.com/sqve/grove/internal/logger"
 )
 
 // LinkResult holds the outcome of a directory linking operation.
@@ -15,7 +19,7 @@ type LinkResult struct {
 }
 
 // LinkDirectoriesToWorktree creates relative symlinks in destDir for directories
-// in sourceDir whose names match any of the given patterns.
+// in sourceDir whose names or relative paths match any of the given patterns.
 // Existing paths in destDir are skipped, never overwritten.
 func LinkDirectoriesToWorktree(sourceDir, destDir string, patterns []string) (*LinkResult, error) {
 	result := &LinkResult{}
@@ -29,6 +33,7 @@ func LinkDirectoriesToWorktree(sourceDir, destDir string, patterns []string) (*L
 		return result, fmt.Errorf("reading source dir %s: %w", sourceDir, err)
 	}
 
+	var names []string
 	for _, entry := range entries {
 		isDir := entry.IsDir()
 		if !isDir && entry.Type()&os.ModeSymlink != 0 {
@@ -45,7 +50,36 @@ func LinkDirectoriesToWorktree(sourceDir, destDir string, patterns []string) (*L
 		if !matchesAnyLinkPattern(name, patterns) {
 			continue
 		}
+		names = append(names, name)
+	}
 
+	for _, pattern := range patterns {
+		if !strings.Contains(pattern, "/") {
+			continue
+		}
+		cleaned := filepath.Clean(filepath.FromSlash(pattern))
+		if filepath.IsAbs(cleaned) || cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) || strings.Contains("/"+filepath.ToSlash(pattern)+"/", "/../") {
+			logger.Debug("Skipping invalid link pattern (path traversal): %s", pattern)
+			continue
+		}
+		matches, err := filepath.Glob(filepath.Join(sourceDir, filepath.FromSlash(pattern)))
+		if err != nil {
+			continue
+		}
+		for _, sourcePath := range matches {
+			info, err := os.Stat(sourcePath)
+			if err != nil || !info.IsDir() {
+				continue
+			}
+			name, err := filepath.Rel(sourceDir, sourcePath)
+			if err != nil {
+				return result, err
+			}
+			names = append(names, name)
+		}
+	}
+
+	for _, name := range names {
 		destPath := filepath.Join(destDir, name)
 		if info, err := os.Lstat(destPath); err == nil {
 			if info.Mode()&os.ModeSymlink != 0 {
@@ -58,8 +92,12 @@ func LinkDirectoriesToWorktree(sourceDir, destDir string, patterns []string) (*L
 			return result, fmt.Errorf("checking dest path %s: %w", destPath, err)
 		}
 
-		relTarget, err := filepath.Rel(destDir, filepath.Join(sourceDir, name))
+		relTarget, err := filepath.Rel(filepath.Dir(destPath), filepath.Join(sourceDir, name))
 		if err != nil {
+			return result, err
+		}
+
+		if err := os.MkdirAll(filepath.Dir(destPath), fs.DirGit); err != nil {
 			return result, err
 		}
 

--- a/internal/workspace/link.go
+++ b/internal/workspace/link.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/sqve/grove/internal/fs"
@@ -57,8 +58,7 @@ func LinkDirectoriesToWorktree(sourceDir, destDir string, patterns []string) (*L
 		if !strings.Contains(pattern, "/") {
 			continue
 		}
-		cleaned := filepath.Clean(filepath.FromSlash(pattern))
-		if filepath.IsAbs(cleaned) || cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) || strings.Contains("/"+filepath.ToSlash(pattern)+"/", "/../") {
+		if isPathTraversal(filepath.FromSlash(pattern)) {
 			logger.Debug("Skipping invalid link pattern (path traversal): %s", pattern)
 			continue
 		}
@@ -79,7 +79,28 @@ func LinkDirectoriesToWorktree(sourceDir, destDir string, patterns []string) (*L
 		}
 	}
 
+	seen := make(map[string]bool, len(names))
+	names = slices.DeleteFunc(names, func(name string) bool {
+		duplicate := seen[name]
+		seen[name] = true
+		return duplicate
+	})
+
+linkLoop:
 	for _, name := range names {
+		parent := destDir
+		parts := strings.Split(name, string(filepath.Separator))
+		for _, part := range parts[:len(parts)-1] {
+			parent = filepath.Join(parent, part)
+			if info, err := os.Lstat(parent); err == nil {
+				if info.Mode()&os.ModeSymlink != 0 {
+					continue linkLoop
+				}
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return result, fmt.Errorf("checking dest parent %s: %w", parent, err)
+			}
+		}
+
 		destPath := filepath.Join(destDir, name)
 		if info, err := os.Lstat(destPath); err == nil {
 			if info.Mode()&os.ModeSymlink != 0 {

--- a/internal/workspace/link.go
+++ b/internal/workspace/link.go
@@ -102,7 +102,9 @@ linkLoop:
 					continue linkLoop
 				}
 			} else if !errors.Is(err, os.ErrNotExist) {
-				return result, fmt.Errorf("checking dest parent %s: %w", parent, err)
+				// A non-directory on the way to destPath blocks this link but not the rest.
+				result.Conflicts = append(result.Conflicts, name)
+				continue linkLoop
 			}
 		}
 

--- a/internal/workspace/link.go
+++ b/internal/workspace/link.go
@@ -86,6 +86,11 @@ func LinkDirectoriesToWorktree(sourceDir, destDir string, patterns []string) (*L
 		return duplicate
 	})
 
+	// Link parents before children so creating a child's directory cannot cause a conflict.
+	slices.SortStableFunc(names, func(a, b string) int {
+		return strings.Count(a, string(filepath.Separator)) - strings.Count(b, string(filepath.Separator))
+	})
+
 linkLoop:
 	for _, name := range names {
 		parent := destDir

--- a/internal/workspace/link.go
+++ b/internal/workspace/link.go
@@ -117,7 +117,8 @@ linkLoop:
 			}
 			continue
 		} else if !errors.Is(err, os.ErrNotExist) {
-			return result, fmt.Errorf("checking dest path %s: %w", destPath, err)
+			result.Conflicts = append(result.Conflicts, name)
+			continue
 		}
 
 		relTarget, err := filepath.Rel(filepath.Dir(destPath), filepath.Join(sourceDir, name))

--- a/internal/workspace/link_test.go
+++ b/internal/workspace/link_test.go
@@ -121,28 +121,41 @@ func TestLinkDirectoriesToWorktree(t *testing.T) {
 
 	t.Run("reports a file at a dest parent as a conflict and keeps linking", func(t *testing.T) {
 		t.Parallel()
-		sourceDir := testutil.TempDir(t)
-		destDir := testutil.TempDir(t)
-		if err := os.MkdirAll(filepath.Join(sourceDir, "apps", "a", "node_modules"), fs.DirStrict); err != nil {
-			t.Fatal(err)
+		tests := []struct {
+			name     string
+			nested   string
+			pattern  string
+			conflict string
+		}{
+			{"one parent component", filepath.Join("apps", "node_modules"), "apps/node_modules", filepath.Join("apps", "node_modules")},
+			{"two parent components", filepath.Join("apps", "a", "node_modules"), "apps/*/node_modules", filepath.Join("apps", "a", "node_modules")},
 		}
-		if err := os.Mkdir(filepath.Join(sourceDir, "vendor"), fs.DirStrict); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(destDir, "apps"), []byte("not a dir"), fs.FileStrict); err != nil {
-			t.Fatal(err)
-		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				sourceDir := testutil.TempDir(t)
+				destDir := testutil.TempDir(t)
+				if err := os.MkdirAll(filepath.Join(sourceDir, tc.nested), fs.DirStrict); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Mkdir(filepath.Join(sourceDir, "vendor"), fs.DirStrict); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(destDir, "apps"), []byte("not a dir"), fs.FileStrict); err != nil {
+					t.Fatal(err)
+				}
 
-		result, err := LinkDirectoriesToWorktree(sourceDir, destDir, []string{"apps/*/node_modules", "vendor"})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(result.Linked) != 1 || result.Linked[0] != "vendor" {
-			t.Errorf("Expected [vendor] in Linked, got %v", result.Linked)
-		}
-		conflict := filepath.Join("apps", "a", "node_modules")
-		if len(result.Conflicts) != 1 || result.Conflicts[0] != conflict {
-			t.Errorf("Expected [%s] in Conflicts, got %v", conflict, result.Conflicts)
+				result, err := LinkDirectoriesToWorktree(sourceDir, destDir, []string{tc.pattern, "vendor"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(result.Linked) != 1 || result.Linked[0] != "vendor" {
+					t.Errorf("Expected [vendor] in Linked, got %v", result.Linked)
+				}
+				if len(result.Conflicts) != 1 || result.Conflicts[0] != tc.conflict {
+					t.Errorf("Expected [%s] in Conflicts, got %v", tc.conflict, result.Conflicts)
+				}
+			})
 		}
 	})
 

--- a/internal/workspace/link_test.go
+++ b/internal/workspace/link_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/sqve/grove/internal/fs"
@@ -56,7 +57,7 @@ func TestLinkDirectoriesToWorktree(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(result.Linked) != 2 || result.Linked[0] != names[0] || result.Linked[1] != names[1] {
+		if !slices.Equal(result.Linked, names) {
 			t.Errorf("Expected %v in Linked, got %v", names, result.Linked)
 		}
 		if len(result.Skipped) != 0 || len(result.Conflicts) != 0 {

--- a/internal/workspace/link_test.go
+++ b/internal/workspace/link_test.go
@@ -12,6 +12,138 @@ import (
 func TestLinkDirectoriesToWorktree(t *testing.T) {
 	t.Parallel()
 
+	t.Run("preserves existing nested destinations and ignores source files", func(t *testing.T) {
+		t.Parallel()
+		sourceDir := testutil.TempDir(t)
+		destDir := testutil.TempDir(t)
+		conflict := filepath.Join("apps", "a", "node_modules")
+		skipped := filepath.Join("apps", "b", "node_modules")
+		for _, name := range []string{conflict, skipped} {
+			if err := os.MkdirAll(filepath.Join(sourceDir, name), fs.DirStrict); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Dir(filepath.Join(destDir, name)), fs.DirStrict); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := os.Mkdir(filepath.Join(destDir, conflict), fs.DirStrict); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("missing", filepath.Join(destDir, skipped)); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(sourceDir, "apps", "c"), fs.DirStrict); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(sourceDir, "apps", "c", "node_modules"), []byte("file"), fs.FileStrict); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LinkDirectoriesToWorktree(sourceDir, destDir, []string{"apps/*/node_modules"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(result.Linked) != 0 {
+			t.Errorf("Expected nothing linked, got %v", result.Linked)
+		}
+		if len(result.Conflicts) != 1 || result.Conflicts[0] != conflict {
+			t.Errorf("Expected [%s] in Conflicts, got %v", conflict, result.Conflicts)
+		}
+		if len(result.Skipped) != 1 || result.Skipped[0] != skipped {
+			t.Errorf("Expected [%s] in Skipped, got %v", skipped, result.Skipped)
+		}
+		info, err := os.Lstat(filepath.Join(destDir, conflict))
+		if err != nil || !info.IsDir() {
+			t.Fatalf("Existing directory changed: %v", err)
+		}
+		target, err := os.Readlink(filepath.Join(destDir, skipped))
+		if err != nil || target != "missing" {
+			t.Fatalf("Existing symlink changed: target %q, error %v", target, err)
+		}
+	})
+
+	t.Run("rejects absolute and parent traversal patterns", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct{ name, pattern string }{
+			{"rejects absolute paths", "/apps/*/node_modules"},
+			{"rejects parent prefixes", "../source/apps/*/node_modules"},
+			{"rejects parent segments", "apps/../apps/*/node_modules"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				root := testutil.TempDir(t)
+				sourceDir := filepath.Join(root, "source")
+				destDir := filepath.Join(root, "dest")
+				if err := os.MkdirAll(filepath.Join(sourceDir, "apps", "a", "node_modules"), fs.DirStrict); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(destDir, fs.DirStrict); err != nil {
+					t.Fatal(err)
+				}
+				pattern := tc.pattern
+				if pattern == "/apps/*/node_modules" {
+					pattern = filepath.VolumeName(sourceDir) + pattern
+				}
+				result, err := LinkDirectoriesToWorktree(sourceDir, destDir, []string{pattern})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(result.Linked) != 0 || len(result.Skipped) != 0 || len(result.Conflicts) != 0 {
+					t.Errorf("Expected invalid pattern %q to be ignored, got %+v", pattern, result)
+				}
+			})
+		}
+	})
+
+	t.Run("links nested directories with resolving relative targets", func(t *testing.T) {
+		t.Parallel()
+		sourceDir := testutil.TempDir(t)
+		destDir := testutil.TempDir(t)
+		names := []string{filepath.Join("apps", "a", "node_modules"), filepath.Join("apps", "b", "node_modules")}
+		for _, name := range names {
+			if err := os.MkdirAll(filepath.Join(sourceDir, name), fs.DirStrict); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		result, err := LinkDirectoriesToWorktree(sourceDir, destDir, []string{"apps/*/node_modules"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(result.Linked) != len(names) {
+			t.Fatalf("Expected %v in Linked, got %v", names, result.Linked)
+		}
+		for i, name := range names {
+			if result.Linked[i] != name {
+				t.Errorf("Expected %q in Linked, got %q", name, result.Linked[i])
+			}
+			destPath := filepath.Join(destDir, name)
+			sourcePath := filepath.Join(sourceDir, name)
+			target, err := os.Readlink(destPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expected, err := filepath.Rel(filepath.Dir(destPath), sourcePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if target != expected || filepath.IsAbs(target) {
+				t.Errorf("Expected relative target %q, got %q", expected, target)
+			}
+			sourceInfo, err := os.Stat(sourcePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			destInfo, err := os.Stat(destPath)
+			if err != nil {
+				t.Fatalf("Symlink does not resolve: %v", err)
+			}
+			if !destInfo.IsDir() || !os.SameFile(sourceInfo, destInfo) {
+				t.Errorf("Symlink %q does not reach source directory %q", destPath, sourcePath)
+			}
+		}
+	})
+
 	t.Run("creates symlinks for matching directories", func(t *testing.T) {
 		t.Parallel()
 		sourceDir := testutil.TempDir(t)

--- a/internal/workspace/link_test.go
+++ b/internal/workspace/link_test.go
@@ -120,6 +120,39 @@ func TestLinkDirectoriesToWorktree(t *testing.T) {
 		}
 	})
 
+	t.Run("matches nested patterns under a source path holding glob characters", func(t *testing.T) {
+		t.Parallel()
+		root := testutil.TempDir(t)
+		sourceDir := filepath.Join(root, "project[1]")
+		destDir := filepath.Join(root, "dest")
+		name := filepath.Join("apps", "a", "node_modules")
+		if err := os.MkdirAll(filepath.Join(sourceDir, name), fs.DirStrict); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(destDir, fs.DirStrict); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LinkDirectoriesToWorktree(sourceDir, destDir, []string{"apps/*/node_modules"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(result.Linked) != 1 || result.Linked[0] != name {
+			t.Fatalf("Expected [%s] in Linked, got %+v", name, result)
+		}
+		sourceInfo, err := os.Stat(filepath.Join(sourceDir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		destInfo, err := os.Stat(filepath.Join(destDir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !os.SameFile(sourceInfo, destInfo) {
+			t.Error("Expected the link to resolve to the source directory")
+		}
+	})
+
 	t.Run("reports a file at a dest parent as a conflict and keeps linking", func(t *testing.T) {
 		t.Parallel()
 		tests := []struct {

--- a/internal/workspace/link_test.go
+++ b/internal/workspace/link_test.go
@@ -12,6 +12,35 @@ import (
 func TestLinkDirectoriesToWorktree(t *testing.T) {
 	t.Parallel()
 
+	t.Run("links parents before children regardless of pattern order", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			name     string
+			patterns []string
+		}{
+			{"child first", []string{"apps/*/node_modules", "apps/*"}},
+			{"parent first", []string{"apps/*", "apps/*/node_modules"}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				sourceDir := testutil.TempDir(t)
+				destDir := testutil.TempDir(t)
+				parent := filepath.Join("apps", "a")
+				if err := os.MkdirAll(filepath.Join(sourceDir, parent, "node_modules"), fs.DirStrict); err != nil {
+					t.Fatal(err)
+				}
+
+				result, err := LinkDirectoriesToWorktree(sourceDir, destDir, tc.patterns)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(result.Linked) != 1 || result.Linked[0] != parent || len(result.Skipped) != 0 || len(result.Conflicts) != 0 {
+					t.Errorf("Expected only parent %q linked, got %+v", parent, result)
+				}
+			})
+		}
+	})
+
 	t.Run("deduplicates overlapping patterns in match order", func(t *testing.T) {
 		t.Parallel()
 		sourceDir := testutil.TempDir(t)

--- a/internal/workspace/link_test.go
+++ b/internal/workspace/link_test.go
@@ -119,6 +119,33 @@ func TestLinkDirectoriesToWorktree(t *testing.T) {
 		}
 	})
 
+	t.Run("reports a file at a dest parent as a conflict and keeps linking", func(t *testing.T) {
+		t.Parallel()
+		sourceDir := testutil.TempDir(t)
+		destDir := testutil.TempDir(t)
+		if err := os.MkdirAll(filepath.Join(sourceDir, "apps", "a", "node_modules"), fs.DirStrict); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(filepath.Join(sourceDir, "vendor"), fs.DirStrict); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(destDir, "apps"), []byte("not a dir"), fs.FileStrict); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LinkDirectoriesToWorktree(sourceDir, destDir, []string{"apps/*/node_modules", "vendor"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(result.Linked) != 1 || result.Linked[0] != "vendor" {
+			t.Errorf("Expected [vendor] in Linked, got %v", result.Linked)
+		}
+		conflict := filepath.Join("apps", "a", "node_modules")
+		if len(result.Conflicts) != 1 || result.Conflicts[0] != conflict {
+			t.Errorf("Expected [%s] in Conflicts, got %v", conflict, result.Conflicts)
+		}
+	})
+
 	t.Run("preserves existing nested destinations and ignores source files", func(t *testing.T) {
 		t.Parallel()
 		sourceDir := testutil.TempDir(t)

--- a/internal/workspace/link_test.go
+++ b/internal/workspace/link_test.go
@@ -12,6 +12,84 @@ import (
 func TestLinkDirectoriesToWorktree(t *testing.T) {
 	t.Parallel()
 
+	t.Run("deduplicates overlapping patterns in match order", func(t *testing.T) {
+		t.Parallel()
+		sourceDir := testutil.TempDir(t)
+		destDir := testutil.TempDir(t)
+		names := []string{filepath.Join("apps", "b", "node_modules"), filepath.Join("apps", "a", "node_modules")}
+		for _, name := range names {
+			if err := os.MkdirAll(filepath.Join(sourceDir, name), fs.DirStrict); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		result, err := LinkDirectoriesToWorktree(sourceDir, destDir, []string{"apps/b/node_modules", "apps/*/node_modules", "apps/a/node_modules"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(result.Linked) != 2 || result.Linked[0] != names[0] || result.Linked[1] != names[1] {
+			t.Errorf("Expected %v in Linked, got %v", names, result.Linked)
+		}
+		if len(result.Skipped) != 0 || len(result.Conflicts) != 0 {
+			t.Errorf("Expected no skips or conflicts, got %+v", result)
+		}
+	})
+
+	t.Run("ignores nested paths beneath linked parents", func(t *testing.T) {
+		t.Parallel()
+		for _, parent := range []string{"apps", "apps/a"} {
+			t.Run(parent, func(t *testing.T) {
+				t.Parallel()
+				sourceDir := testutil.TempDir(t)
+				destDir := testutil.TempDir(t)
+				name := filepath.Join("apps", "a", "node_modules")
+				if err := os.MkdirAll(filepath.Join(sourceDir, name), fs.DirStrict); err != nil {
+					t.Fatal(err)
+				}
+
+				result, err := LinkDirectoriesToWorktree(sourceDir, destDir, []string{parent, "apps/*/node_modules"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(result.Linked) != 1 || result.Linked[0] != filepath.FromSlash(parent) || len(result.Skipped) != 0 || len(result.Conflicts) != 0 {
+					t.Errorf("Expected only parent %q linked, got %+v", parent, result)
+				}
+				info, err := os.Stat(filepath.Join(destDir, name))
+				if err != nil || !info.IsDir() {
+					t.Fatalf("Nested directory is not reachable: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("does not create directories through existing parent symlinks", func(t *testing.T) {
+		t.Parallel()
+		sourceDir := testutil.TempDir(t)
+		destDir := testutil.TempDir(t)
+		targetDir := testutil.TempDir(t)
+		if err := os.MkdirAll(filepath.Join(sourceDir, "apps", "a", "node_modules"), fs.DirStrict); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(targetDir, filepath.Join(destDir, "apps")); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LinkDirectoriesToWorktree(sourceDir, destDir, []string{"apps/*/node_modules"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(result.Linked) != 0 || len(result.Skipped) != 0 || len(result.Conflicts) != 0 {
+			t.Errorf("Expected empty result, got %+v", result)
+		}
+		entries, err := os.ReadDir(targetDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(entries) != 0 {
+			t.Errorf("Expected symlink target untouched, got %v", entries)
+		}
+	})
+
 	t.Run("preserves existing nested destinations and ignores source files", func(t *testing.T) {
 		t.Parallel()
 		sourceDir := testutil.TempDir(t)
@@ -67,7 +145,7 @@ func TestLinkDirectoriesToWorktree(t *testing.T) {
 		for _, tc := range []struct{ name, pattern string }{
 			{"rejects absolute paths", "/apps/*/node_modules"},
 			{"rejects parent prefixes", "../source/apps/*/node_modules"},
-			{"rejects parent segments", "apps/../apps/*/node_modules"},
+			{"rejects escaping parent segments", "apps/../../source/apps/*/node_modules"},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
@@ -92,6 +170,23 @@ func TestLinkDirectoriesToWorktree(t *testing.T) {
 					t.Errorf("Expected invalid pattern %q to be ignored, got %+v", pattern, result)
 				}
 			})
+		}
+	})
+
+	t.Run("accepts parent segments that clean to a safe path", func(t *testing.T) {
+		t.Parallel()
+		sourceDir := testutil.TempDir(t)
+		destDir := testutil.TempDir(t)
+		if err := os.Mkdir(filepath.Join(sourceDir, "b"), fs.DirStrict); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LinkDirectoriesToWorktree(sourceDir, destDir, []string{"a/../b"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(result.Linked) != 1 || result.Linked[0] != "b" {
+			t.Errorf("Expected [b] in Linked, got %v", result.Linked)
 		}
 	})
 

--- a/internal/workspace/preserve.go
+++ b/internal/workspace/preserve.go
@@ -76,7 +76,7 @@ func PreserveFilesToWorktree(sourceDir, destDir string, patterns, ignoredFiles, 
 
 // PreserveDirectoriesToWorktree recursively copies named directories from source to dest.
 // Skips directories that don't exist in source. Skips individual files that already exist in dest.
-// Rejects directory names with path traversal (absolute paths or ".." components).
+// Rejects absolute paths and paths that resolve outside the source directory.
 func PreserveDirectoriesToWorktree(sourceDir, destDir string, directories []string) (*PreserveResult, error) {
 	result := &PreserveResult{}
 
@@ -86,7 +86,7 @@ func PreserveDirectoriesToWorktree(sourceDir, destDir string, directories []stri
 
 	for _, dir := range directories {
 		cleaned := filepath.Clean(dir)
-		if filepath.IsAbs(cleaned) || cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		if isPathTraversal(dir) {
 			logger.Debug("Skipping invalid preserve directory (path traversal): %s", dir)
 			continue
 		}
@@ -139,6 +139,11 @@ func PreserveDirectoriesToWorktree(sourceDir, destDir string, directories []stri
 	}
 
 	return result, nil
+}
+
+func isPathTraversal(path string) bool {
+	cleaned := filepath.Clean(path)
+	return filepath.IsAbs(cleaned) || cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator))
 }
 
 func FindIgnoredFilesInWorktree(worktreeDir string) ([]string, error) {


### PR DESCRIPTION
**`[link]` patterns containing a path separator now match nested directories instead of silently linking nothing.**

`LinkDirectoriesToWorktree` only read the source worktree's root entries and matched them with `filepath.Match`, so a pattern like `apps/*/node_modules` could never match and monorepo teams had no way to share per-package caches. Patterns with a `/` now glob against the source tree and link each match at the same relative path in the new worktree; patterns without one keep the existing root-name behavior untouched.

#### Changes

- Patterns containing `/` are globbed against the source worktree, and each matching directory is linked at the same relative path in the destination, creating parent directories as needed. The symlink target is computed from the destination's own parent, so nested links resolve.
- Shallower paths are linked before deeper ones, so results no longer depend on the order patterns appear in `.grove.toml`, and a directory grove creates itself is never reported as a conflict.
- A path already reachable through a symlinked parent in the destination is left alone rather than reported as a conflict, and nothing is written through that symlink into the source worktree.
- A non-directory blocking a destination path is recorded as a conflict and linking continues, instead of aborting the run and silently dropping every later pattern.
- Overlapping patterns that match the same directory link it once, rather than reporting it as both linked and skipped.
- Patterns that escape the source worktree (absolute paths, or `..` segments that resolve outside it) are rejected by `isPathTraversal`, now shared with `[preserve]` so both settings accept and reject the same paths. A `..` that normalizes back inside, such as `a/../b`, stays valid, matching existing `[preserve]` behavior.
- README documents that patterns with `/` match relative paths, with a monorepo `apps/*/node_modules` example.

#### Decisions

- Nested patterns are detected with `strings.Contains(pattern, "/")` rather than `filepath.Separator`, because CI runs on windows-latest where the separator is `\` and config is written with forward slashes.
- Permission and quota failures on `MkdirAll` and `os.Symlink` still abort the run; they affect every pattern equally and surface as a real error, so per-pattern resilience there would hide a genuine problem.
- `cmd/grove/commands/list.go` extracts a `filterLocked` constant, unrelated to this change: `"locked"` reached three occurrences on `main` and `goconst` fails CI at that threshold, so the branch could not go green without it.

#### Test plan

- [x] Code review by Claude Opus 5 (cape:code-reviewer) on 4561b03, findings addressed or dismissed
- [x] `make ci` passes
- [x] `apps/*/node_modules` links each match as a symlink that resolves to the source directory
- [x] Patterns without `/` match root names exactly as on `main`
- [x] Existing destination symlink is reported in `Skipped`; existing real directory in `Conflicts`, keyed by relative path
- [x] `["apps/*/node_modules", "apps/*"]` and its reverse produce identical results
- [x] A regular file at a destination parent yields a conflict for that path while later patterns still link
- [x] Patterns escaping the source worktree are rejected identically by `[link]` and `[preserve]`, and `a/../b` is accepted by both

---

Fixes ABU-272, AI-55
