### PR TITLE
Release v1.10.1

### DIFF
--- a/.changes/unreleased/fixed-IZebvGcN.yaml
+++ b/.changes/unreleased/fixed-IZebvGcN.yaml
@@ -1,5 +1,0 @@
-kind: Fixed
-body: Resolve the default branch from origin/HEAD before bare HEAD, main, and master, checking existing local refs without network access (AI-134).
-time: 2026-09-07T14:29:34.057077769+02:00
-custom:
-  Issue: ''

--- a/.changes/unreleased/fixed-KvecqMyt.yaml
+++ b/.changes/unreleased/fixed-KvecqMyt.yaml
@@ -1,5 +1,0 @@
-kind: Fixed
-body: Link nested directories matched by path patterns such as apps/*/node_modules, using relative symlinks so the links resolve.
-time: 2026-09-07T14:30:31.952371956+02:00
-custom:
-  Issue: ''

--- a/.changes/v1.10.1.md
+++ b/.changes/v1.10.1.md
@@ -1,0 +1,5 @@
+## [v1.10.1](https://github.com/sQVe/grove/releases/tag/v1.10.1) - 2026-09-07
+
+### Fixed
+- Resolve the default branch from origin/HEAD before bare HEAD, main, and master, checking existing local refs without network access (AI-134).
+- Link nested directories matched by path patterns such as apps/*/node_modules, using relative symlinks so the links resolve.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v1.10.1](https://github.com/sQVe/grove/releases/tag/v1.10.1) - 2026-09-07
+
+### Fixed
+- Resolve the default branch from origin/HEAD before bare HEAD, main, and master, checking existing local refs without network access (AI-134).
+- Link nested directories matched by path patterns such as apps/*/node_modules, using relative symlinks so the links resolve.
+
 ## [v1.10.0](https://github.com/sQVe/grove/releases/tag/v1.10.0) - 2026-09-04
 
 ### Added


### PR DESCRIPTION
This PR was created by the [Changie release GitHub action](https://github.com/labd/changie-release-action). When you're ready to do a release, you can merge this and the tag v1.10.1 will be created.  If you're not ready to do a release yet, that's fine, whenever you add more changes to main, this PR will be updated.

# Releases
## [v1.10.1](https://github.com/sQVe/grove/releases/tag/v1.10.1) - 2026-09-07

### Fixed
- Resolve the default branch from origin/HEAD before bare HEAD, main, and master, checking existing local refs without network access (AI-134).
- Link nested directories matched by path patterns such as apps/*/node_modules, using relative symlinks so the links resolve.