### PR TITLE
feat(add): base new branches on the fetched default branch

### DIFF
--- a/.changes/unreleased/changed-rmG3Qolz.yaml
+++ b/.changes/unreleased/changed-rmG3Qolz.yaml
@@ -1,4 +1,4 @@
-kind: Fixed
+kind: Changed
 body: Base new branches on the fetched origin default branch, with offline fallback warnings and fetch opt-outs.
 time: 2026-09-07T17:05:21.627212356+02:00
 custom:

--- a/.changes/unreleased/fixed-rmG3Qolz.yaml
+++ b/.changes/unreleased/fixed-rmG3Qolz.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Base new branches on the fetched origin default branch, with offline fallback warnings and fetch opt-outs.
+time: 2026-09-07T17:05:21.627212356+02:00
+custom:
+  Issue: ''

--- a/README.md
+++ b/README.md
@@ -223,10 +223,10 @@ grove add --from dev feat/auth # Copy .env from dev worktree
 New branches start from the default branch on origin, fetched with a five-second timeout.
 If fetching fails, Grove warns with the base ref and commit age, then uses the existing
 origin ref, local default branch, or bare HEAD. Local branches and worktrees stay unchanged.
-An explicit `--base` uses its origin counterpart when available. Use `--no-fetch` to skip
-fetching once, or `grove config set --global grove.fetchBase false` to disable it by
-default. Both keep the newest local ref, which is the bare repository's HEAD when nothing
-else resolves.
+An explicit `--base` uses its origin counterpart when available, and `--base HEAD` selects
+the bare repository's HEAD. Use `--no-fetch` to skip fetching once, or
+`grove config set --global grove.fetchBase false` to disable it by default. Both leave the
+refs on disk untouched and pick from them in the same order.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ Add a worktree for a branch, pull request, or ref.
 **Flags:**
 
 - `-s, --switch` — Switch to worktree after creating
-- `--base <branch>` — Create new branch from base instead of HEAD
+- `--base <branch>` — Create new branch from this base instead of the default branch
+- `--no-fetch` — Skip fetching the base branch
 - `--name <name>` — Custom directory name
 - `-d, --detach` — Detached HEAD state
 - `--pr <number>` — Create worktree for a pull request
@@ -218,6 +219,13 @@ grove add --pr 123 --reset     # PR, discarding local commits
 grove add --detach v1.0.0      # Tag in detached HEAD
 grove add --from dev feat/auth # Copy .env from dev worktree
 ```
+
+New branches start from the default branch on origin, fetched with a five-second timeout.
+If fetching fails, Grove warns with the base ref and commit age, then uses the existing
+origin ref, local default branch, or bare HEAD. Local branches and worktrees stay unchanged.
+An explicit `--base` uses its origin counterpart when available. Use `--base HEAD` for
+local HEAD, `--no-fetch` to skip fetching once, or
+`grove config set --global grove.fetchBase false` to disable it by default.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -223,9 +223,10 @@ grove add --from dev feat/auth # Copy .env from dev worktree
 New branches start from the default branch on origin, fetched with a five-second timeout.
 If fetching fails, Grove warns with the base ref and commit age, then uses the existing
 origin ref, local default branch, or bare HEAD. Local branches and worktrees stay unchanged.
-An explicit `--base` uses its origin counterpart when available. Use `--base HEAD` for
-local HEAD, `--no-fetch` to skip fetching once, or
-`grove config set --global grove.fetchBase false` to disable it by default.
+An explicit `--base` uses its origin counterpart when available. Use `--no-fetch` to skip
+fetching once, or `grove config set --global grove.fetchBase false` to disable it by
+default. Both keep the newest local ref, which is the bare repository's HEAD when nothing
+else resolves.
 
 </details>
 
@@ -553,6 +554,9 @@ plain = false
 
 # Enable debug logging.
 debug = false
+
+# Fetch the base branch from origin before creating a new branch.
+fetch_base = true
 
 [preserve]
 # Files to copy from the current worktree when creating a new one.

--- a/cmd/grove/add_integration_test.go
+++ b/cmd/grove/add_integration_test.go
@@ -37,9 +37,15 @@ func TestAdd(t *testing.T) {
 		cmd := exec.CommandContext(ctx, "grove", "add", "bounded-fetch")
 		cmd.Dir = w.BareDir
 		cmd.WaitDelay = time.Second
+		start := time.Now()
 		out, err := cmd.CombinedOutput()
+		elapsed := time.Since(start)
 		if err != nil {
 			t.Fatalf("add failed: %v\n%s", err, out)
+		}
+		// The fetch budget is five seconds; the stall lasts ten, so anything slower waited on it.
+		if elapsed >= 10*time.Second {
+			t.Fatalf("add took %s, want the fetch to give up well inside the stall", elapsed)
 		}
 		if strings.Count(string(out), "basing on origin/main from ") != 1 || !strings.Contains(string(out), "ago - fetch failed") {
 			t.Fatalf("expected one warning with base and age, got %s", out)

--- a/cmd/grove/add_integration_test.go
+++ b/cmd/grove/add_integration_test.go
@@ -1,0 +1,48 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	gitutil "github.com/sqve/grove/internal/testutil/git"
+)
+
+func TestAdd(t *testing.T) {
+	t.Parallel()
+	t.Run("returns a worktree when the base fetch times out", func(t *testing.T) {
+		t.Parallel()
+		origin := gitutil.NewTestRepo(t)
+		w := gitutil.NewGroveWorkspace(t)
+		w.RunOutput("remote", "add", "origin", "file://"+origin.Path)
+		w.RunOutput("fetch", "origin", "refs/heads/main:refs/remotes/origin/main")
+		w.RunOutput("config", "grove.timeout", "30s")
+		w.RunOutput("config", "grove.fetchBase", "true")
+		// Stall the real upload-pack process, leaving git fetch waiting for a response.
+		w.RunOutput("config", "remote.origin.uploadpack", "sleep 30; git-upload-pack")
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "grove", "add", "bounded-fetch")
+		cmd.Dir = w.BareDir
+		cmd.WaitDelay = time.Second
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("add failed: %v\n%s", err, out)
+		}
+		if strings.Count(string(out), "basing on origin/main from ") != 1 || !strings.Contains(string(out), "ago - fetch failed") {
+			t.Fatalf("expected one warning with base and age, got %s", out)
+		}
+		if _, err := os.Stat(filepath.Join(w.Dir, "bounded-fetch", ".git")); err != nil {
+			t.Fatal(err)
+		}
+		if got, want := w.RunOutput("rev-parse", "bounded-fetch"), w.RunOutput("rev-parse", "origin/main"); got != want {
+			t.Fatalf("worktree commit = %s, want %s", got, want)
+		}
+	})
+}

--- a/cmd/grove/add_integration_test.go
+++ b/cmd/grove/add_integration_test.go
@@ -25,8 +25,8 @@ func TestAdd(t *testing.T) {
 		w.RunOutput("config", "grove.timeout", "30s")
 		w.RunOutput("config", "grove.fetchBase", "true")
 		// Stall the real upload-pack process, leaving git fetch waiting for a response.
-		w.RunOutput("config", "remote.origin.uploadpack", "sleep 30; git-upload-pack")
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		w.RunOutput("config", "remote.origin.uploadpack", "sleep 10; git-upload-pack")
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		cmd := exec.CommandContext(ctx, "grove", "add", "bounded-fetch")
 		cmd.Dir = w.BareDir

--- a/cmd/grove/add_integration_test.go
+++ b/cmd/grove/add_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +19,11 @@ func TestAdd(t *testing.T) {
 	t.Parallel()
 	t.Run("returns a worktree when the base fetch times out", func(t *testing.T) {
 		t.Parallel()
+		if runtime.GOOS == "windows" {
+			// Killing git leaves the stalled upload-pack holding the repository open,
+			// and Windows cannot delete open files, so TempDir cleanup fails (AI-140).
+			t.Skip("stalled upload-pack keeps the repository open on Windows")
+		}
 		origin := gitutil.NewTestRepo(t)
 		w := gitutil.NewGroveWorkspace(t)
 		w.RunOutput("remote", "add", "origin", "file://"+origin.Path)

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -21,6 +21,7 @@ func NewAddCmd() *cobra.Command {
 	var baseBranch string
 	var name string
 	var detach bool
+	var noFetch bool
 	var prNumber int
 	var reset bool
 	var from string
@@ -45,17 +46,18 @@ Examples:
 		ValidArgsFunction: completeAddArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switchTo, _ := cmd.Flags().GetBool("switch")
-			return runAdd(args, switchTo, baseBranch, name, detach, prNumber, reset, from)
+			return runAdd(args, switchTo, baseBranch, name, detach, prNumber, reset, from, noFetch)
 		},
 	}
 
 	cmd.Flags().BoolP("switch", "s", false, "Switch to the worktree after creating it")
-	cmd.Flags().StringVar(&baseBranch, "base", "", "Create new branch from this base instead of HEAD")
+	cmd.Flags().StringVar(&baseBranch, "base", "", "Create new branch from this base instead of the default branch")
 	cmd.Flags().StringVar(&name, "name", "", "Custom directory name for the worktree")
 	cmd.Flags().BoolVarP(&detach, "detach", "d", false, "Create worktree in detached HEAD state")
 	cmd.Flags().IntVar(&prNumber, "pr", 0, "Pull request number to checkout")
 	cmd.Flags().BoolVar(&reset, "reset", false, "Reset diverged PR branch to match remote (discards local commits)")
 	cmd.Flags().StringVar(&from, "from", "", "Source worktree for file preservation (name or branch)")
+	cmd.Flags().BoolVar(&noFetch, "no-fetch", false, "Skip fetching the base branch from origin")
 	cmd.Flags().BoolP("help", "h", false, "Help for add")
 
 	_ = cmd.RegisterFlagCompletionFunc("base", completeBaseBranch)
@@ -70,7 +72,7 @@ Examples:
 	return cmd
 }
 
-func runAdd(args []string, switchTo bool, baseBranch, name string, detach bool, prNumber int, reset bool, from string) error {
+func runAdd(args []string, switchTo bool, baseBranch, name string, detach bool, prNumber int, reset bool, from string, noFetch bool) error {
 	name = strings.TrimSpace(name)
 	if name == "." || name == ".." || strings.ContainsAny(name, `/\`) {
 		return fmt.Errorf("--name must be a single directory name")
@@ -206,10 +208,10 @@ func runAdd(args []string, switchTo bool, baseBranch, name string, detach bool, 
 	}
 
 	// Regular branch creation
-	return runAddFromBranch(branchOrPR, switchTo, baseBranch, name, bareDir, workspaceRoot, sourceWorktree, releaseLock)
+	return runAddFromBranch(branchOrPR, switchTo, baseBranch, name, bareDir, workspaceRoot, sourceWorktree, releaseLock, !noFetch && config.IsFetchBase())
 }
 
-func runAddFromBranch(branch string, switchTo bool, baseBranch, name, bareDir, workspaceRoot, sourceWorktree string, releaseLock func()) error {
+func runAddFromBranch(branch string, switchTo bool, baseBranch, name, bareDir, workspaceRoot, sourceWorktree string, releaseLock func(), fetchBase bool) error {
 	dirName := name
 	if dirName == "" {
 		dirName = workspace.SanitizeBranchName(branch)
@@ -266,22 +268,12 @@ func runAddFromBranch(branch string, switchTo bool, baseBranch, name, bareDir, w
 			}
 		}
 	} else {
-		if baseBranch != "" {
-			// Validate base branch exists
-			baseExists, err := git.BranchExists(bareDir, baseBranch)
-			if err != nil {
-				return fmt.Errorf("failed to check base branch: %w", err)
-			}
-			if !baseExists {
-				return fmt.Errorf("base branch %q does not exist", baseBranch)
-			}
-			if err := git.CreateWorktree(bareDir, worktreePath, git.CreateWorktreeOptions{Branch: branch, NewBranch: true, Base: baseBranch}, true); err != nil {
-				return git.HintGitTooOld(fmt.Errorf("failed to create worktree: %w", err))
-			}
-		} else {
-			if err := git.CreateWorktree(bareDir, worktreePath, git.CreateWorktreeOptions{Branch: branch, NewBranch: true}, true); err != nil {
-				return git.HintGitTooOld(fmt.Errorf("failed to create worktree: %w", err))
-			}
+		base, err := git.ResolveWorktreeBase(bareDir, baseBranch, fetchBase)
+		if err != nil {
+			return err
+		}
+		if err := git.CreateWorktree(bareDir, worktreePath, git.CreateWorktreeOptions{Branch: branch, NewBranch: true, Base: base}, true); err != nil {
+			return git.HintGitTooOld(fmt.Errorf("failed to create worktree: %w", err))
 		}
 	}
 

--- a/cmd/grove/commands/add_test.go
+++ b/cmd/grove/commands/add_test.go
@@ -75,7 +75,7 @@ func TestRunAdd_NotInWorkspace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = runAdd([]string{"feature-test"}, false, "", "", false, 0, false, "")
+	err = runAdd([]string{"feature-test"}, false, "", "", false, 0, false, "", false)
 	if !errors.Is(err, workspace.ErrNotInWorkspace) {
 		t.Errorf("expected ErrNotInWorkspace, got %v", err)
 	}
@@ -94,56 +94,56 @@ func TestRunAdd_PRValidation(t *testing.T) {
 	}
 
 	t.Run("base flag cannot be used with --pr", func(t *testing.T) {
-		err := runAdd(nil, false, "main", "", false, 123, false, "")
+		err := runAdd(nil, false, "main", "", false, 123, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--base cannot be used with PR") {
 			t.Errorf("expected base/PR error, got %v", err)
 		}
 	})
 
 	t.Run("detach flag cannot be used with --pr", func(t *testing.T) {
-		err := runAdd(nil, false, "", "", true, 123, false, "")
+		err := runAdd(nil, false, "", "", true, 123, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--detach cannot be used with PR") {
 			t.Errorf("expected detach/PR error, got %v", err)
 		}
 	})
 
 	t.Run("negative --pr gives clear error", func(t *testing.T) {
-		err := runAdd(nil, false, "", "", false, -5, false, "")
+		err := runAdd(nil, false, "", "", false, -5, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--pr must be a positive number") {
 			t.Errorf("expected positive number error, got %v", err)
 		}
 	})
 
 	t.Run("--pr cannot be combined with positional argument", func(t *testing.T) {
-		err := runAdd([]string{"feature"}, false, "", "", false, 123, false, "")
+		err := runAdd([]string{"feature"}, false, "", "", false, 123, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--pr flag cannot be combined with positional argument") {
 			t.Errorf("expected --pr/positional conflict error, got %v", err)
 		}
 	})
 
 	t.Run("old #N syntax gives helpful error", func(t *testing.T) {
-		err := runAdd([]string{"#123"}, false, "", "", false, 0, false, "")
+		err := runAdd([]string{"#123"}, false, "", "", false, 0, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "syntax no longer supported") {
 			t.Errorf("expected helpful migration error, got %v", err)
 		}
 	})
 
 	t.Run("base flag cannot be used with PR URL", func(t *testing.T) {
-		err := runAdd([]string{"https://github.com/owner/repo/pull/456"}, false, "main", "", false, 0, false, "")
+		err := runAdd([]string{"https://github.com/owner/repo/pull/456"}, false, "main", "", false, 0, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--base cannot be used with PR") {
 			t.Errorf("expected base/PR error, got %v", err)
 		}
 	})
 
 	t.Run("detach flag cannot be used with PR URL", func(t *testing.T) {
-		err := runAdd([]string{"https://github.com/owner/repo/pull/456"}, false, "", "", true, 0, false, "")
+		err := runAdd([]string{"https://github.com/owner/repo/pull/456"}, false, "", "", true, 0, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--detach cannot be used with PR") {
 			t.Errorf("expected detach/PR error, got %v", err)
 		}
 	})
 
 	t.Run("reset flag can only be used with PR references", func(t *testing.T) {
-		err := runAdd([]string{"feature-branch"}, false, "", "", false, 0, true, "")
+		err := runAdd([]string{"feature-branch"}, false, "", "", false, 0, true, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--reset can only be used with PR references") {
 			t.Errorf("expected --reset/PR error, got %v", err)
 		}
@@ -152,7 +152,7 @@ func TestRunAdd_PRValidation(t *testing.T) {
 
 func TestRunAdd_DetachBaseValidation(t *testing.T) {
 	t.Run("detach and base cannot be used together", func(t *testing.T) {
-		err := runAdd([]string{"v1.0.0"}, false, "main", "", true, 0, false, "")
+		err := runAdd([]string{"v1.0.0"}, false, "main", "", true, 0, false, "", false)
 		if err == nil || err.Error() != "--detach and --base cannot be used together" {
 			t.Errorf("expected detach/base error, got %v", err)
 		}
@@ -175,14 +175,14 @@ func TestRunAdd_InputValidation(t *testing.T) {
 	t.Run("whitespace-only branch name", func(t *testing.T) {
 		// Whitespace is trimmed, resulting in empty string
 		// This should fail with "requires branch" error
-		err := runAdd([]string{"   "}, false, "", "", false, 0, false, "")
+		err := runAdd([]string{"   "}, false, "", "", false, 0, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "requires branch") {
 			t.Errorf("expected 'requires branch' error for whitespace-only branch name, got %v", err)
 		}
 	})
 
 	t.Run("no args and no --pr flag", func(t *testing.T) {
-		err := runAdd(nil, false, "", "", false, 0, false, "")
+		err := runAdd(nil, false, "", "", false, 0, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "requires branch") {
 			t.Errorf("expected 'requires branch' error, got %v", err)
 		}
@@ -192,7 +192,7 @@ func TestRunAdd_InputValidation(t *testing.T) {
 		// The trimming happens, then workspace detection runs
 		// We're not in a workspace, so we'll get that error
 		// But this verifies the trim doesn't crash
-		err := runAdd([]string{"  feature-test  "}, false, "", "", false, 0, false, "")
+		err := runAdd([]string{"  feature-test  "}, false, "", "", false, 0, false, "", false)
 		if !errors.Is(err, workspace.ErrNotInWorkspace) {
 			t.Errorf("expected ErrNotInWorkspace after trimming, got %v", err)
 		}
@@ -201,14 +201,14 @@ func TestRunAdd_InputValidation(t *testing.T) {
 	t.Run("PR URL with /files suffix works", func(t *testing.T) {
 		// PR URLs with /files suffix should be detected as PR references
 		// Flag validation happens before workspace detection
-		err := runAdd([]string{"https://github.com/owner/repo/pull/123/files"}, false, "main", "", false, 0, false, "")
+		err := runAdd([]string{"https://github.com/owner/repo/pull/123/files"}, false, "main", "", false, 0, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--base cannot be used with PR") {
 			t.Errorf("expected base/PR error for URL with /files suffix, got %v", err)
 		}
 	})
 
 	t.Run("PR URL with query params works", func(t *testing.T) {
-		err := runAdd([]string{"https://github.com/owner/repo/pull/123?diff=split"}, false, "", "", true, 0, false, "")
+		err := runAdd([]string{"https://github.com/owner/repo/pull/123?diff=split"}, false, "", "", true, 0, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--detach cannot be used with PR") {
 			t.Errorf("expected detach/PR error for URL with query params, got %v", err)
 		}
@@ -820,7 +820,7 @@ func TestRunAdd_FromValidation(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err := runAdd([]string{"feature-test"}, false, "", "", false, 0, false, "nonexistent")
+		err := runAdd([]string{"feature-test"}, false, "", "", false, 0, false, "nonexistent", false)
 		if err == nil {
 			t.Fatal("expected error for nonexistent --from worktree")
 		}
@@ -857,7 +857,7 @@ func TestRunAdd_FromValidation(t *testing.T) {
 		})
 
 		// Create a new worktree with --from pointing to source
-		err := runAdd([]string{"feature-from-test"}, false, "", "", false, 0, false, "source")
+		err := runAdd([]string{"feature-from-test"}, false, "", "", false, 0, false, "source", false)
 		if err != nil {
 			t.Errorf("expected success with valid --from, got %v", err)
 		}
@@ -938,7 +938,7 @@ func TestRunAddFromBranch_WorktreeExistsHint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = runAdd([]string{"main"}, false, "", "", false, 0, false, "")
+	err = runAdd([]string{"main"}, false, "", "", false, 0, false, "", false)
 	if err == nil {
 		t.Fatal("expected error for existing worktree")
 	}
@@ -1014,7 +1014,7 @@ func TestRunAdd_LinkPatternsAppliedFromOutsideWorktree(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runAdd([]string{"feat"}, false, "", "", false, 0, false, ""); err != nil {
+	if err := runAdd([]string{"feat"}, false, "", "", false, 0, false, "", false); err != nil {
 		t.Fatalf("runAdd: %v", err)
 	}
 
@@ -1096,7 +1096,7 @@ func TestRunAdd_LinkAppliedWhenOnlyNonMainWorktreeHasConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runAdd([]string{"newwork"}, false, "", "", false, 0, false, ""); err != nil {
+	if err := runAdd([]string{"newwork"}, false, "", "", false, 0, false, "", false); err != nil {
 		t.Fatalf("runAdd: %v", err)
 	}
 

--- a/cmd/grove/commands/config.go
+++ b/cmd/grove/commands/config.go
@@ -455,6 +455,10 @@ func runConfigGetShared(key string) error {
 		if cfg.Plain != nil {
 			fmt.Println(*cfg.Plain)
 		}
+	case strings.ToLower(configKeyFetchBase), tomlKeyFetchBase:
+		if cfg.FetchBase != nil {
+			fmt.Println(*cfg.FetchBase)
+		}
 	case configKeyDebug, tomlKeyDebug:
 		if cfg.Debug != nil {
 			fmt.Println(*cfg.Debug)

--- a/cmd/grove/commands/config.go
+++ b/cmd/grove/commands/config.go
@@ -18,6 +18,7 @@ import (
 const (
 	configKeyPlain     = "grove.plain"
 	configKeyDebug     = "grove.debug"
+	configKeyFetchBase = "grove.fetchBase"
 	configKeyNerdFonts = "grove.nerdFonts"
 	configKeyPreserve  = "grove.preserve"
 	configKeyHooksAdd  = "hooks.add"
@@ -27,8 +28,8 @@ const (
 )
 
 var (
-	allConfigKeys     = []string{configKeyPlain, configKeyDebug, configKeyNerdFonts, configKeyPreserve}
-	booleanConfigKeys = []string{configKeyPlain, configKeyDebug, configKeyNerdFonts}
+	allConfigKeys     = []string{configKeyPlain, configKeyDebug, configKeyNerdFonts, configKeyPreserve, configKeyFetchBase}
+	booleanConfigKeys = []string{configKeyPlain, configKeyDebug, configKeyNerdFonts, configKeyFetchBase}
 )
 
 // isValidConfigKey validates that key is in grove.* namespace
@@ -409,6 +410,7 @@ func runConfigListEffective() error {
 	cfg.Link.Patterns = config.GetMergedLinkPatterns(worktreeDir)
 	cfg.Autolock.Patterns = config.GetAutoLockPatterns()
 	printFileConfig(&cfg)
+	fmt.Printf("grove.fetchBase=%t\n", config.IsFetchBase())
 	return nil
 }
 
@@ -489,6 +491,8 @@ func runConfigGetEffective(key string) error {
 	worktreeDir := findWorktreeDir()
 
 	switch strings.ToLower(key) {
+	case "grove.fetchbase":
+		fmt.Println(config.IsFetchBase())
 	case configKeyPlain, tomlKeyPlain:
 		fmt.Println(config.GetMergedPlain(worktreeDir))
 	case configKeyDebug, tomlKeyDebug:

--- a/cmd/grove/commands/config.go
+++ b/cmd/grove/commands/config.go
@@ -25,6 +25,7 @@ const (
 	tomlKeyPlain       = "plain"
 	tomlKeyDebug       = "debug"
 	tomlKeyPreserve    = "preserve.patterns"
+	tomlKeyFetchBase   = "fetch_base"
 )
 
 var (
@@ -336,6 +337,9 @@ func printFileConfig(cfg *config.FileConfig) {
 	if cfg.NerdFonts != nil {
 		fmt.Printf("nerd_fonts=%t\n", *cfg.NerdFonts)
 	}
+	if cfg.FetchBase != nil {
+		fmt.Printf("fetch_base=%t\n", *cfg.FetchBase)
+	}
 	if cfg.StaleThreshold != "" {
 		fmt.Printf("stale_threshold=%s\n", cfg.StaleThreshold)
 	}
@@ -402,7 +406,8 @@ func runConfigListEffective() error {
 	}
 
 	plain, debug, nerdFonts := config.GetMergedPlain(worktreeDir), config.GetMergedDebug(worktreeDir), config.IsNerdFonts()
-	cfg.Plain, cfg.Debug, cfg.NerdFonts = &plain, &debug, &nerdFonts
+	fetchBase := config.IsFetchBase()
+	cfg.Plain, cfg.Debug, cfg.NerdFonts, cfg.FetchBase = &plain, &debug, &nerdFonts, &fetchBase
 	cfg.StaleThreshold = config.GetStaleThreshold()
 	cfg.Preserve.Patterns = config.GetMergedPreservePatterns(worktreeDir)
 	cfg.Preserve.Exclude = config.GetMergedPreserveExcludePatterns(worktreeDir)
@@ -410,7 +415,6 @@ func runConfigListEffective() error {
 	cfg.Link.Patterns = config.GetMergedLinkPatterns(worktreeDir)
 	cfg.Autolock.Patterns = config.GetAutoLockPatterns()
 	printFileConfig(&cfg)
-	fmt.Printf("grove.fetchBase=%t\n", config.IsFetchBase())
 	return nil
 }
 
@@ -491,7 +495,8 @@ func runConfigGetEffective(key string) error {
 	worktreeDir := findWorktreeDir()
 
 	switch strings.ToLower(key) {
-	case "grove.fetchbase":
+	// The switch lowercases its input, so the camelCase constant cannot be a case here.
+	case strings.ToLower(configKeyFetchBase), tomlKeyFetchBase:
 		fmt.Println(config.IsFetchBase())
 	case configKeyPlain, tomlKeyPlain:
 		fmt.Println(config.GetMergedPlain(worktreeDir))

--- a/cmd/grove/commands/config_test.go
+++ b/cmd/grove/commands/config_test.go
@@ -148,7 +148,7 @@ func TestGetConfigCompletions(t *testing.T) {
 		{
 			name:       "empty completion shows all keys",
 			toComplete: "",
-			want:       []string{"grove.debug", "grove.nerdFonts", "grove.plain", "grove.preserve"},
+			want:       []string{"grove.debug", "grove.fetchBase", "grove.nerdFonts", "grove.plain", "grove.preserve"},
 		},
 		{
 			name:       "partial grove.p completion",

--- a/cmd/grove/testdata/script/add_explicit_remote_base.txt
+++ b/cmd/grove/testdata/script/add_explicit_remote_base.txt
@@ -10,6 +10,16 @@ exec grove add --base origin/develop from-qualified
 exec git -C ../from-qualified rev-parse HEAD
 cmp stdout $WORK/expected
 
+# A qualified base is fetched even when its tracking ref was pruned.
+exec git update-ref -d refs/remotes/origin/develop
+exec grove add --base origin/develop from-pruned
+exec git -C ../from-pruned rev-parse HEAD
+cmp stdout $WORK/expected
+
+# A qualified base that origin does not have is still an error.
+! exec grove add --base origin/nope from-missing
+stderr 'base branch "origin/nope" does not exist'
+
 # A local-only base remains literal and never contacts origin.
 exec git branch local-only
 exec git remote set-url origin $WORK/missing

--- a/cmd/grove/testdata/script/add_explicit_remote_base.txt
+++ b/cmd/grove/testdata/script/add_explicit_remote_base.txt
@@ -1,0 +1,21 @@
+setup_workspace develop
+exec git -C $WORK/testrepo worktree add $WORK/develop develop
+exec git -C $WORK/develop commit --allow-empty -m upstream
+exec git -C $WORK/develop rev-parse HEAD
+cp stdout $WORK/expected
+exec grove add --base develop from-develop
+exec git -C ../from-develop rev-parse HEAD
+cmp stdout $WORK/expected
+exec grove add --base origin/develop from-qualified
+exec git -C ../from-qualified rev-parse HEAD
+cmp stdout $WORK/expected
+
+# A local-only base remains literal and never contacts origin.
+exec git branch local-only
+exec git remote set-url origin $WORK/missing
+exec grove add --base local-only from-local
+! stderr 'fetch failed'
+exec git rev-parse local-only
+cp stdout $WORK/local
+exec git -C ../from-local rev-parse HEAD
+cmp stdout $WORK/local

--- a/cmd/grove/testdata/script/add_fetched_base.txt
+++ b/cmd/grove/testdata/script/add_fetched_base.txt
@@ -1,0 +1,26 @@
+# Fetch the default branch without touching a dirty default worktree.
+setup_workspace
+exec git rev-parse HEAD
+cp stdout $WORK/head-before
+cp $WORK/dirty README.md
+exec git status --porcelain=v1
+cp stdout $WORK/status-before
+exec git -C $WORK/testrepo commit --allow-empty -m upstream
+exec git -C $WORK/testrepo rev-parse HEAD
+cp stdout $WORK/upstream
+
+# Even a configured local destination must not be updated by this fetch.
+exec git config remote.origin.fetch +refs/heads/*:refs/heads/*
+exec grove add feature/fetched
+exec git -C ../feature-fetched rev-parse HEAD
+cmp stdout $WORK/upstream
+exec git rev-parse origin/main
+cmp stdout $WORK/upstream
+exec git rev-parse HEAD
+cmp stdout $WORK/head-before
+exec git status --porcelain=v1
+cmp stdout $WORK/status-before
+cmp README.md $WORK/dirty
+
+-- dirty --
+uncommitted work

--- a/cmd/grove/testdata/script/add_from_flag.txt
+++ b/cmd/grove/testdata/script/add_from_flag.txt
@@ -8,7 +8,7 @@ exec git commit -m 'add from-test gitignore'
 exec git config --add grove.preserve .env.from-test
 
 # Create another worktree to use as source
-exec grove add --base main feature/alt-source-2
+exec grove add --base HEAD feature/alt-source-2
 
 # Create unique content in alt-source worktree
 cp $WORK/env-alt ../feature-alt-source-2/.env.from-test
@@ -18,7 +18,7 @@ cp $WORK/env-main .env.from-test
 
 # Create worktree from workspace root with --from pointing to alt-source
 cd $WORK/workspace
-exec grove add --from feature-alt-source-2 feature/from-flag-test
+exec grove add --base HEAD --from feature-alt-source-2 feature/from-flag-test
 stderr 'Created worktree at .*[/\\]feature-from-flag-test'
 stderr 'preserved'
 stderr '.env.from-test'

--- a/cmd/grove/testdata/script/add_no_fetch.txt
+++ b/cmd/grove/testdata/script/add_no_fetch.txt
@@ -1,6 +1,6 @@
 setup_workspace
 exec grove config list
-stdout 'grove.fetchBase=true'
+stdout 'fetch_base=true'
 exec grove config get grove.fetchBase
 stdout '^true$'
 exec git rev-parse origin/main
@@ -16,7 +16,7 @@ cmp stdout $WORK/before
 
 exec grove config set --global grove.fetchBase false
 exec grove config list
-stdout 'grove.fetchBase=false'
+stdout 'fetch_base=false'
 exec grove add config-skipped
 ! stderr 'fetch failed'
 exec git rev-parse origin/main
@@ -30,3 +30,18 @@ stdout 'grove.fetchBase'
 exec grove __complete config set grove.fetchBase ''
 stdout 'true'
 stdout 'false'
+
+# .grove.toml carries the key too, so a team can disable the fetch for the repository.
+exec grove config unset --global grove.fetchBase
+cp $WORK/toml .grove.toml
+exec grove config list
+stdout 'fetch_base=false'
+exec grove add toml-skipped
+! stderr 'fetch failed'
+exec git rev-parse origin/main
+cmp stdout $WORK/before
+exec git -C ../toml-skipped rev-parse HEAD
+cmp stdout $WORK/before
+
+-- toml --
+fetch_base = false

--- a/cmd/grove/testdata/script/add_no_fetch.txt
+++ b/cmd/grove/testdata/script/add_no_fetch.txt
@@ -1,0 +1,32 @@
+setup_workspace
+exec grove config list
+stdout 'grove.fetchBase=true'
+exec grove config get grove.fetchBase
+stdout '^true$'
+exec git rev-parse origin/main
+cp stdout $WORK/before
+exec git -C $WORK/testrepo commit --allow-empty -m upstream
+
+exec grove add --no-fetch flag-skipped
+! stderr 'fetch failed'
+exec git rev-parse origin/main
+cmp stdout $WORK/before
+exec git -C ../flag-skipped rev-parse HEAD
+cmp stdout $WORK/before
+
+exec grove config set --global grove.fetchBase false
+exec grove config list
+stdout 'grove.fetchBase=false'
+exec grove add config-skipped
+! stderr 'fetch failed'
+exec git rev-parse origin/main
+cmp stdout $WORK/before
+exec git -C ../config-skipped rev-parse HEAD
+cmp stdout $WORK/before
+exec grove config list --global
+stdout 'grove.fetchbase.*false'
+exec grove __complete config set grove.fetch
+stdout 'grove.fetchBase'
+exec grove __complete config set grove.fetchBase ''
+stdout 'true'
+stdout 'false'

--- a/cmd/grove/testdata/script/add_no_remote.txt
+++ b/cmd/grove/testdata/script/add_no_remote.txt
@@ -28,3 +28,11 @@ exec git rev-parse HEAD
 cp stdout $WORK/cloned-head
 exec git -C ../feature-orphaned rev-parse HEAD
 cmp stdout $WORK/cloned-head
+
+# Commits exist but no default branch resolves: still a degraded base, so still a warning.
+exec grove add dev
+cd ../dev
+exec grove remove main --force
+exec git branch -D main
+exec grove add feature/dangling
+stderr 'basing on HEAD from .* - default branch unavailable'

--- a/cmd/grove/testdata/script/add_no_remote.txt
+++ b/cmd/grove/testdata/script/add_no_remote.txt
@@ -6,6 +6,8 @@ exec grove init new workspace
 cd workspace
 exec grove add main
 ! stderr 'basing on'
+exec grove add --base HEAD other
+! stderr 'basing on'
 cd main
 
 # A workspace that never had a remote resolves the local default branch silently.
@@ -29,10 +31,19 @@ cp stdout $WORK/cloned-head
 exec git -C ../feature-orphaned rev-parse HEAD
 cmp stdout $WORK/cloned-head
 
-# Commits exist but no default branch resolves: still a degraded base, so still a warning.
+# Commits exist but HEAD points at a deleted branch: refuse rather than start from nothing.
 exec grove add dev
 cd ../dev
 exec grove remove main --force
 exec git branch -D main
-exec grove add feature/dangling
-stderr 'basing on HEAD from .* - default branch unavailable'
+! exec grove add feature/dangling
+stderr 'HEAD points at a branch that no longer exists'
+stderr 'pass --base'
+! exists ../feature-dangling
+
+# An explicit base still works there.
+exec grove add --base dev feature/based
+exec git rev-parse dev
+cp stdout $WORK/dev-head
+exec git -C ../feature-based rev-parse HEAD
+cmp stdout $WORK/dev-head

--- a/cmd/grove/testdata/script/add_no_remote.txt
+++ b/cmd/grove/testdata/script/add_no_remote.txt
@@ -1,0 +1,30 @@
+# A workspace without origin has nothing to fetch, so nothing to warn about.
+
+# The first branch of an empty workspace has no commit to base on.
+mkdir workspace
+exec grove init new workspace
+cd workspace
+exec grove add main
+! stderr 'basing on'
+cd main
+
+# A workspace that never had a remote resolves the local default branch silently.
+exec git commit --allow-empty -m initial
+exec grove add feature/local
+! stderr 'basing on'
+exec git rev-parse HEAD
+cp stdout $WORK/expected
+exec git -C ../feature-local rev-parse HEAD
+cmp stdout $WORK/expected
+
+# Losing origin is the same case: no fetch to fail, no warning.
+cd $WORK
+exec grove clone file://$WORK/workspace/main cloned
+cd cloned/main
+exec git remote remove origin
+exec grove add feature/orphaned
+! stderr 'basing on'
+exec git rev-parse HEAD
+cp stdout $WORK/cloned-head
+exec git -C ../feature-orphaned rev-parse HEAD
+cmp stdout $WORK/cloned-head

--- a/cmd/grove/testdata/script/add_offline_base.txt
+++ b/cmd/grove/testdata/script/add_offline_base.txt
@@ -1,0 +1,24 @@
+# An unavailable origin warns once with the selected ref and commit age.
+setup_workspace
+exec git remote set-url origin $WORK/missing
+exec git rev-parse origin/main
+cp stdout $WORK/expected
+exec grove add offline-remote
+stderr -count=1 'basing on origin/main from .+ ago - fetch failed'
+exec git -C ../offline-remote rev-parse HEAD
+cmp stdout $WORK/expected
+
+# Without a remote-tracking ref, use the local default branch.
+exec git update-ref -d refs/remotes/origin/main
+exec grove add offline-local
+stderr -count=1 'basing on main from .+ ago - fetch failed'
+exec git -C ../offline-local rev-parse HEAD
+cmp stdout $WORK/expected
+
+# A detached bare HEAD and no default branch still provides an explicit base.
+exec git -C ../.bare update-ref --no-deref HEAD main
+exec git -C ../.bare update-ref -d refs/heads/main
+exec grove add offline-head
+stderr -count=1 'basing on HEAD from .+ ago'
+exec git -C ../offline-head rev-parse HEAD
+cmp stdout $WORK/expected

--- a/cmd/grove/testdata/script/add_skipped_files.txt
+++ b/cmd/grove/testdata/script/add_skipped_files.txt
@@ -8,7 +8,7 @@ exec git add .gitignore
 exec git commit -m 'add env-skip-test to gitignore'
 
 # First add creates worktree
-exec grove add feature/skip-test
+exec grove add --base HEAD feature/skip-test
 exists ../feature-skip-test
 
 # Create the file in destination
@@ -19,7 +19,7 @@ exec grove remove feature-skip-test
 
 # Modify source file and re-add
 cp $WORK/env-skip-modified .env-skip-test
-exec grove add feature/skip-test-2
+exec grove add --base HEAD feature/skip-test-2
 stderr 'Created worktree at'
 
 -- env-skip-test --

--- a/cmd/grove/testdata/script/add_upstream.txt
+++ b/cmd/grove/testdata/script/add_upstream.txt
@@ -1,0 +1,15 @@
+# The base is a start point, never an upstream.
+
+setup_workspace develop
+
+# A new branch based on origin/main must not end up tracking main.
+exec grove add feature/fresh
+! exec git config branch.feature/fresh.remote
+! exec git config branch.feature/fresh.merge
+
+# An existing remote branch still tracks its own counterpart.
+exec grove add develop
+exec git config branch.develop.remote
+stdout '^origin$'
+exec git config branch.develop.merge
+stdout '^refs/heads/develop$'

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ var globalMu sync.RWMutex
 
 type settings struct {
 	Plain            bool
+	FetchBase        bool
 	Debug            bool
 	NerdFonts        bool
 	StaleThreshold   string
@@ -40,6 +41,7 @@ var Global settings
 var DefaultConfig = defaultSettings{
 	settings: settings{
 		Plain:          false,
+		FetchBase:      true,
 		Debug:          false,
 		NerdFonts:      true,
 		StaleThreshold: "30d",
@@ -81,6 +83,13 @@ func IsPlain() bool {
 	globalMu.RLock()
 	defer globalMu.RUnlock()
 	return Global.Plain
+}
+
+// IsFetchBase reports whether add should fetch its base branch.
+func IsFetchBase() bool {
+	globalMu.RLock()
+	defer globalMu.RUnlock()
+	return Global.FetchBase
 }
 
 // IsDebug returns true if debug logging is enabled
@@ -221,6 +230,10 @@ func loadGlobalConfig(fileConfig *FileConfig) {
 
 	if value := getGitConfig("grove.plain"); value != "" {
 		loaded.Plain = isTruthy(value)
+	}
+
+	if value := getGitConfig("grove.fetchBase"); value != "" {
+		loaded.FetchBase = isTruthy(value)
 	}
 
 	if value := getGitConfig("grove.debug"); value != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -221,6 +221,9 @@ func loadGlobalConfig(fileConfig *FileConfig) {
 	if fileConfig.NerdFonts != nil {
 		loaded.NerdFonts = *fileConfig.NerdFonts
 	}
+	if fileConfig.FetchBase != nil {
+		loaded.FetchBase = *fileConfig.FetchBase
+	}
 	if isValidStaleThreshold(fileConfig.StaleThreshold) {
 		loaded.StaleThreshold = fileConfig.StaleThreshold
 	}

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -34,6 +34,7 @@ type FileConfig struct {
 	Plain          *bool  `toml:"plain"`
 	Debug          *bool  `toml:"debug"`
 	NerdFonts      *bool  `toml:"nerd_fonts"`
+	FetchBase      *bool  `toml:"fetch_base"`
 	StaleThreshold string `toml:"stale_threshold"`
 }
 

--- a/internal/config/grove.template.toml
+++ b/internal/config/grove.template.toml
@@ -14,6 +14,9 @@ plain = false
 # Enable debug logging.
 debug = false
 
+# Fetch the base branch from origin before creating a new branch.
+fetch_base = true
+
 [preserve]
 # Files to copy from the current worktree when creating a new one.
 # Useful for environment files and local configuration that shouldn't be in git.

--- a/internal/git/base.go
+++ b/internal/git/base.go
@@ -30,12 +30,15 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 		var err error
 		branch, err = GetDefaultBranch(bareDir)
 		if err != nil {
-			warnWorktreeBase(bareDir, headRef, "default branch unavailable")
+			// A repository without commits has no branch to base on yet, which is not a degraded base.
+			if unborn, headErr := isHeadDangling(bareDir); headErr != nil || !unborn {
+				warnWorktreeBase(bareDir, headRef, "default branch unavailable")
+			}
 			return headRef, nil
 		}
 	}
 	var fetchErr error
-	if fetch {
+	if hasOrigin, _ := RemoteExists(bareDir, "origin"); fetch && hasOrigin {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", "--refmap=", "origin", "+refs/heads/"+branch+":refs/remotes/origin/"+branch) //nolint:gosec // Branch resolved from git

--- a/internal/git/base.go
+++ b/internal/git/base.go
@@ -16,12 +16,14 @@ const headRef = "HEAD"
 // ResolveWorktreeBase selects an explicit start point, optionally refreshing origin.
 func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 	branch := strings.TrimPrefix(base, "origin/")
+	qualified := strings.HasPrefix(base, "origin/")
 	if base != "" {
 		remote, err := RemoteBranchExists(bareDir, "origin", branch)
 		if err != nil {
 			return "", fmt.Errorf("failed to check origin/%s: %w", branch, err)
 		}
-		if !remote || base == headRef {
+		// A qualified base names a remote branch, so fetch it before calling it missing.
+		if (!remote && !qualified) || base == headRef {
 			// An empty repository has no ref to verify; CreateWorktree starts an orphan branch.
 			if base == headRef {
 				empty, emptyErr := hasNoBranches(bareDir)
@@ -72,6 +74,8 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 	switch {
 	case remote:
 		base = "origin/" + branch
+	case qualified:
+		return "", fmt.Errorf("base branch \"origin/%s\" does not exist", branch)
 	case local:
 		base = branch
 	}

--- a/internal/git/base.go
+++ b/internal/git/base.go
@@ -30,21 +30,24 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 		var err error
 		branch, err = GetDefaultBranch(bareDir)
 		if err != nil {
-			// A repository without commits has no branch to base on yet, which is not a degraded base.
-			if unborn, headErr := isHeadDangling(bareDir); headErr != nil || !unborn {
+			// A repository without branches has nothing to base on yet, which is not a degraded base.
+			if empty, emptyErr := hasNoBranches(bareDir); emptyErr != nil || !empty {
 				warnWorktreeBase(bareDir, headRef, "default branch unavailable")
 			}
 			return headRef, nil
 		}
 	}
 	var fetchErr error
-	if hasOrigin, _ := RemoteExists(bareDir, "origin"); fetch && hasOrigin {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", "--refmap=", "origin", "+refs/heads/"+branch+":refs/remotes/origin/"+branch) //nolint:gosec // Branch resolved from git
-		cmd.Dir = bareDir
-		cmd.WaitDelay = time.Second
-		fetchErr = runGitCommand(cmd, true)
+	if fetch {
+		// An unreadable remote list is treated as a remote, so a real failure still warns.
+		if hasOrigin, originErr := RemoteExists(bareDir, "origin"); originErr != nil || hasOrigin {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", "--refmap=", "origin", "+refs/heads/"+branch+":refs/remotes/origin/"+branch) //nolint:gosec // Branch resolved from git
+			cmd.Dir = bareDir
+			cmd.WaitDelay = time.Second
+			fetchErr = runGitCommand(cmd, true)
+		}
 	}
 	base = headRef
 	if exists, _ := RemoteBranchExists(bareDir, "origin", branch); exists {
@@ -57,6 +60,18 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 		warnWorktreeBase(bareDir, base, "fetch failed")
 	}
 	return base, nil
+}
+
+// hasNoBranches reports whether the repository holds no branches at all.
+func hasNoBranches(bareDir string) (bool, error) {
+	cmd, cancel := GitCommand("git", "for-each-ref", "--count=1", "--format=%(refname)", "refs/heads")
+	defer cancel()
+	cmd.Dir = bareDir
+	refs, err := executeWithOutput(cmd)
+	if err != nil {
+		return false, err
+	}
+	return refs == "", nil
 }
 
 func warnWorktreeBase(bareDir, base, reason string) {

--- a/internal/git/base.go
+++ b/internal/git/base.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -16,7 +17,21 @@ const headRef = "HEAD"
 func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 	branch := strings.TrimPrefix(base, "origin/")
 	if base != "" {
-		if exists, _ := RemoteBranchExists(bareDir, "origin", branch); !exists || base == headRef {
+		remote, err := RemoteBranchExists(bareDir, "origin", branch)
+		if err != nil {
+			return "", fmt.Errorf("failed to check origin/%s: %w", branch, err)
+		}
+		if !remote || base == headRef {
+			// An empty repository has no ref to verify; CreateWorktree starts an orphan branch.
+			if base == headRef {
+				empty, emptyErr := hasNoBranches(bareDir)
+				if emptyErr != nil {
+					return "", emptyErr
+				}
+				if empty {
+					return headRef, nil
+				}
+			}
 			exists, err := BranchExists(bareDir, base)
 			if err != nil {
 				return "", err
@@ -30,11 +45,7 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 		var err error
 		branch, err = GetDefaultBranch(bareDir)
 		if err != nil {
-			// A repository without branches has nothing to base on yet, which is not a degraded base.
-			if empty, emptyErr := hasNoBranches(bareDir); emptyErr != nil || !empty {
-				warnWorktreeBase(bareDir, headRef, "default branch unavailable")
-			}
-			return headRef, nil
+			return resolveHeadBase(bareDir)
 		}
 	}
 	var fetchErr error
@@ -50,9 +61,18 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 		}
 	}
 	base = headRef
-	if exists, _ := RemoteBranchExists(bareDir, "origin", branch); exists {
+	remote, remoteErr := RemoteBranchExists(bareDir, "origin", branch)
+	if remoteErr != nil {
+		return "", fmt.Errorf("failed to check origin/%s: %w", branch, remoteErr)
+	}
+	local, localErr := LocalBranchExists(bareDir, branch)
+	if localErr != nil {
+		return "", fmt.Errorf("failed to check branch %s: %w", branch, localErr)
+	}
+	switch {
+	case remote:
 		base = "origin/" + branch
-	} else if exists, _ := LocalBranchExists(bareDir, branch); exists {
+	case local:
 		base = branch
 	}
 	if fetchErr != nil {
@@ -60,6 +80,27 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 		warnWorktreeBase(bareDir, base, "fetch failed")
 	}
 	return base, nil
+}
+
+// resolveHeadBase falls back to the bare repository's HEAD once no default branch resolves.
+func resolveHeadBase(bareDir string) (string, error) {
+	dangling, err := isHeadDangling(bareDir)
+	if err != nil {
+		return "", err
+	}
+	if !dangling {
+		warnWorktreeBase(bareDir, headRef, "default branch unavailable")
+		return headRef, nil
+	}
+	// A repository without branches has nothing to base on yet, which is not a degraded base.
+	empty, err := hasNoBranches(bareDir)
+	if err != nil {
+		return "", err
+	}
+	if empty {
+		return headRef, nil
+	}
+	return "", errors.New("cannot resolve a base branch: HEAD points at a branch that no longer exists; pass --base <branch>")
 }
 
 // hasNoBranches reports whether the repository holds no local or remote-tracking branches.

--- a/internal/git/base.go
+++ b/internal/git/base.go
@@ -1,0 +1,68 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/sqve/grove/internal/logger"
+)
+
+const headRef = "HEAD"
+
+// ResolveWorktreeBase selects an explicit start point, optionally refreshing origin.
+func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
+	branch := strings.TrimPrefix(base, "origin/")
+	if base != "" {
+		if exists, _ := RemoteBranchExists(bareDir, "origin", branch); !exists || base == headRef {
+			exists, err := BranchExists(bareDir, base)
+			if err != nil {
+				return "", err
+			}
+			if !exists {
+				return "", fmt.Errorf("base branch %q does not exist", base)
+			}
+			return base, nil
+		}
+	} else {
+		var err error
+		branch, err = GetDefaultBranch(bareDir)
+		if err != nil {
+			warnWorktreeBase(bareDir, headRef, "default branch unavailable")
+			return headRef, nil
+		}
+	}
+	var fetchErr error
+	if fetch {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", "--refmap=", "origin", "refs/heads/"+branch+":refs/remotes/origin/"+branch) //nolint:gosec // Branch resolved from git
+		cmd.Dir = bareDir
+		cmd.WaitDelay = time.Second
+		fetchErr = runGitCommand(cmd, true)
+	}
+	base = headRef
+	if exists, _ := RemoteBranchExists(bareDir, "origin", branch); exists {
+		base = "origin/" + branch
+	} else if exists, _ := LocalBranchExists(bareDir, branch); exists {
+		base = branch
+	}
+	if fetchErr != nil {
+		logger.Debug("Base fetch failed: %v", fetchErr)
+		warnWorktreeBase(bareDir, base, "fetch failed")
+	}
+	return base, nil
+}
+
+func warnWorktreeBase(bareDir, base, reason string) {
+	cmd, cancel := GitCommand("git", "log", "-1", "--format=%cr", base, "--")
+	defer cancel()
+	cmd.Dir = bareDir
+	age, err := executeWithOutput(cmd)
+	if err != nil || age == "" {
+		age = "unknown time"
+	}
+	logger.Warning("basing on %s from %s - %s", base, age, reason)
+}

--- a/internal/git/base.go
+++ b/internal/git/base.go
@@ -62,9 +62,9 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 	return base, nil
 }
 
-// hasNoBranches reports whether the repository holds no branches at all.
+// hasNoBranches reports whether the repository holds no local or remote-tracking branches.
 func hasNoBranches(bareDir string) (bool, error) {
-	cmd, cancel := GitCommand("git", "for-each-ref", "--count=1", "--format=%(refname)", "refs/heads")
+	cmd, cancel := GitCommand("git", "for-each-ref", "--count=1", "--format=%(refname)", "refs/heads", "refs/remotes")
 	defer cancel()
 	cmd.Dir = bareDir
 	refs, err := executeWithOutput(cmd)

--- a/internal/git/base.go
+++ b/internal/git/base.go
@@ -38,7 +38,7 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 	if fetch {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", "--refmap=", "origin", "refs/heads/"+branch+":refs/remotes/origin/"+branch) //nolint:gosec // Branch resolved from git
+		cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", "--refmap=", "origin", "+refs/heads/"+branch+":refs/remotes/origin/"+branch) //nolint:gosec // Branch resolved from git
 		cmd.Dir = bareDir
 		cmd.WaitDelay = time.Second
 		fetchErr = runGitCommand(cmd, true)

--- a/internal/git/base_test.go
+++ b/internal/git/base_test.go
@@ -10,6 +10,45 @@ import (
 	testgit "github.com/sqve/grove/internal/testutil/git"
 )
 
+func TestHasNoBranches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns true for a repository without branches", func(t *testing.T) {
+		t.Parallel()
+		bareDir := filepath.Join(testutil.TempDir(t), "empty.bare")
+		if err := os.Mkdir(bareDir, fs.DirStrict); err != nil {
+			t.Fatalf("failed to create bare directory: %v", err)
+		}
+		if err := InitBare(bareDir); err != nil {
+			t.Fatalf("InitBare() error = %v", err)
+		}
+
+		empty, err := hasNoBranches(bareDir)
+		if err != nil {
+			t.Fatalf("hasNoBranches() error = %v", err)
+		}
+		if !empty {
+			t.Fatal("hasNoBranches() = false, want true")
+		}
+	})
+
+	t.Run("returns false when HEAD dangles over an existing branch", func(t *testing.T) {
+		t.Parallel()
+		w := testgit.NewGroveWorkspace(t)
+		w.RunOutput("branch", "dev")
+		w.RunOutput("worktree", "remove", "--force", filepath.Join(w.Dir, "main"))
+		w.RunOutput("branch", "-D", "main")
+
+		empty, err := hasNoBranches(w.BareDir)
+		if err != nil {
+			t.Fatalf("hasNoBranches() error = %v", err)
+		}
+		if empty {
+			t.Fatal("hasNoBranches() = true, want false")
+		}
+	})
+}
+
 func TestResolveWorktreeBase(t *testing.T) {
 	t.Parallel()
 
@@ -88,6 +127,22 @@ func TestResolveWorktreeBase(t *testing.T) {
 		}
 		if base != "local-only" {
 			t.Fatalf("base = %q, want local-only", base)
+		}
+	})
+
+	t.Run("returns HEAD when no default branch resolves", func(t *testing.T) {
+		t.Parallel()
+		w := testgit.NewGroveWorkspace(t)
+		w.RunOutput("branch", "dev")
+		w.RunOutput("worktree", "remove", "--force", filepath.Join(w.Dir, "main"))
+		w.RunOutput("branch", "-D", "main")
+
+		base, err := ResolveWorktreeBase(w.BareDir, "", false)
+		if err != nil {
+			t.Fatalf("ResolveWorktreeBase() error = %v", err)
+		}
+		if base != headRef {
+			t.Fatalf("base = %q, want %s", base, headRef)
 		}
 	})
 

--- a/internal/git/base_test.go
+++ b/internal/git/base_test.go
@@ -1,0 +1,102 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sqve/grove/internal/fs"
+	"github.com/sqve/grove/internal/testutil"
+	testgit "github.com/sqve/grove/internal/testutil/git"
+)
+
+func TestResolveWorktreeBase(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns the remote-tracking ref when it exists", func(t *testing.T) {
+		t.Parallel()
+		w := testgit.NewGroveWorkspace(t)
+		origin := testgit.NewTestRepo(t)
+		w.RunOutput("remote", "add", "origin", origin.Path)
+		w.RunOutput("fetch", "origin", "+refs/heads/main:refs/remotes/origin/main")
+
+		base, err := ResolveWorktreeBase(w.BareDir, "", false)
+		if err != nil {
+			t.Fatalf("ResolveWorktreeBase() error = %v", err)
+		}
+		if base != "origin/main" {
+			t.Fatalf("base = %q, want origin/main", base)
+		}
+	})
+
+	t.Run("falls back to the local default branch without a remote-tracking ref", func(t *testing.T) {
+		t.Parallel()
+		w := testgit.NewGroveWorkspace(t)
+
+		base, err := ResolveWorktreeBase(w.BareDir, "", false)
+		if err != nil {
+			t.Fatalf("ResolveWorktreeBase() error = %v", err)
+		}
+		if base != "main" {
+			t.Fatalf("base = %q, want main", base)
+		}
+	})
+
+	t.Run("returns HEAD for a repository without commits", func(t *testing.T) {
+		t.Parallel()
+		bareDir := filepath.Join(testutil.TempDir(t), "empty.bare")
+		if err := os.Mkdir(bareDir, fs.DirStrict); err != nil {
+			t.Fatalf("failed to create bare directory: %v", err)
+		}
+		if err := InitBare(bareDir); err != nil {
+			t.Fatalf("InitBare() error = %v", err)
+		}
+
+		base, err := ResolveWorktreeBase(bareDir, "", true)
+		if err != nil {
+			t.Fatalf("ResolveWorktreeBase() error = %v", err)
+		}
+		if base != headRef {
+			t.Fatalf("base = %q, want %s", base, headRef)
+		}
+	})
+
+	t.Run("resolves an explicit base to its origin counterpart", func(t *testing.T) {
+		t.Parallel()
+		w := testgit.NewGroveWorkspace(t)
+		origin := testgit.NewTestRepo(t)
+		w.RunOutput("remote", "add", "origin", origin.Path)
+		w.RunOutput("fetch", "origin", "+refs/heads/main:refs/remotes/origin/main")
+
+		base, err := ResolveWorktreeBase(w.BareDir, "main", false)
+		if err != nil {
+			t.Fatalf("ResolveWorktreeBase() error = %v", err)
+		}
+		if base != "origin/main" {
+			t.Fatalf("base = %q, want origin/main", base)
+		}
+	})
+
+	t.Run("keeps a local-only base literal", func(t *testing.T) {
+		t.Parallel()
+		w := testgit.NewGroveWorkspace(t)
+		w.RunOutput("branch", "local-only")
+
+		base, err := ResolveWorktreeBase(w.BareDir, "local-only", true)
+		if err != nil {
+			t.Fatalf("ResolveWorktreeBase() error = %v", err)
+		}
+		if base != "local-only" {
+			t.Fatalf("base = %q, want local-only", base)
+		}
+	})
+
+	t.Run("returns an error for a base that does not exist", func(t *testing.T) {
+		t.Parallel()
+		w := testgit.NewGroveWorkspace(t)
+
+		if _, err := ResolveWorktreeBase(w.BareDir, "missing", true); err == nil {
+			t.Fatal("expected an error for a missing base branch")
+		}
+	})
+}

--- a/internal/git/base_test.go
+++ b/internal/git/base_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestHasNoBranches(t *testing.T) {
-	t.Parallel()
-
 	t.Run("returns true for a repository without branches", func(t *testing.T) {
 		t.Parallel()
 		bareDir := filepath.Join(testutil.TempDir(t), "empty.bare")
@@ -71,8 +69,6 @@ func TestHasNoBranches(t *testing.T) {
 }
 
 func TestResolveWorktreeBase(t *testing.T) {
-	t.Parallel()
-
 	t.Run("returns the remote-tracking ref when it exists", func(t *testing.T) {
 		t.Parallel()
 		w := testgit.NewGroveWorkspace(t)
@@ -158,11 +154,27 @@ func TestResolveWorktreeBase(t *testing.T) {
 		}
 	})
 
-	t.Run("warns and returns HEAD when no default branch resolves", func(t *testing.T) {
+	t.Run("returns an error when HEAD points at a deleted branch", func(t *testing.T) {
 		w := testgit.NewGroveWorkspace(t)
 		w.RunOutput("branch", "dev")
 		w.RunOutput("worktree", "remove", "--force", filepath.Join(w.Dir, "main"))
 		w.RunOutput("branch", "-D", "main")
+
+		_, err := ResolveWorktreeBase(w.BareDir, "", false)
+		if err == nil {
+			t.Fatal("expected an error when HEAD points at a deleted branch")
+		}
+		if !strings.Contains(err.Error(), "--base") {
+			t.Fatalf("error = %v, want it to suggest --base", err)
+		}
+	})
+
+	t.Run("warns and returns HEAD when a detached HEAD has no default branch", func(t *testing.T) {
+		w := testgit.NewGroveWorkspace(t)
+		head := strings.TrimSpace(w.RunOutput("rev-parse", "HEAD"))
+		w.RunOutput("worktree", "remove", "--force", filepath.Join(w.Dir, "main"))
+		w.RunOutput("update-ref", "--no-deref", "HEAD", head)
+		w.RunOutput("update-ref", "-d", "refs/heads/main")
 
 		var buf bytes.Buffer
 		logger.SetOutput(&buf)
@@ -178,6 +190,24 @@ func TestResolveWorktreeBase(t *testing.T) {
 		}
 		if !strings.Contains(buf.String(), "default branch unavailable") {
 			t.Fatalf("warning = %q, want it to name the unavailable default branch", buf.String())
+		}
+	})
+
+	t.Run("returns HEAD for an explicit HEAD base in an empty repository", func(t *testing.T) {
+		bareDir := filepath.Join(testutil.TempDir(t), "empty.bare")
+		if err := os.Mkdir(bareDir, fs.DirStrict); err != nil {
+			t.Fatalf("failed to create bare directory: %v", err)
+		}
+		if err := InitBare(bareDir); err != nil {
+			t.Fatalf("InitBare() error = %v", err)
+		}
+
+		base, err := ResolveWorktreeBase(bareDir, headRef, false)
+		if err != nil {
+			t.Fatalf("ResolveWorktreeBase() error = %v", err)
+		}
+		if base != headRef {
+			t.Fatalf("base = %q, want %s", base, headRef)
 		}
 	})
 

--- a/internal/git/base_test.go
+++ b/internal/git/base_test.go
@@ -1,11 +1,14 @@
 package git
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sqve/grove/internal/fs"
+	"github.com/sqve/grove/internal/logger"
 	"github.com/sqve/grove/internal/testutil"
 	testgit "github.com/sqve/grove/internal/testutil/git"
 )
@@ -29,6 +32,24 @@ func TestHasNoBranches(t *testing.T) {
 		}
 		if !empty {
 			t.Fatal("hasNoBranches() = false, want true")
+		}
+	})
+
+	t.Run("returns false when only remote-tracking refs exist", func(t *testing.T) {
+		t.Parallel()
+		w := testgit.NewGroveWorkspace(t)
+		origin := testgit.NewTestRepo(t)
+		w.RunOutput("remote", "add", "origin", origin.Path)
+		w.RunOutput("fetch", "origin", "+refs/heads/main:refs/remotes/origin/main")
+		w.RunOutput("worktree", "remove", "--force", filepath.Join(w.Dir, "main"))
+		w.RunOutput("branch", "-D", "main")
+
+		empty, err := hasNoBranches(w.BareDir)
+		if err != nil {
+			t.Fatalf("hasNoBranches() error = %v", err)
+		}
+		if empty {
+			t.Fatal("hasNoBranches() = true, want false")
 		}
 	})
 
@@ -82,7 +103,6 @@ func TestResolveWorktreeBase(t *testing.T) {
 	})
 
 	t.Run("returns HEAD for a repository without commits", func(t *testing.T) {
-		t.Parallel()
 		bareDir := filepath.Join(testutil.TempDir(t), "empty.bare")
 		if err := os.Mkdir(bareDir, fs.DirStrict); err != nil {
 			t.Fatalf("failed to create bare directory: %v", err)
@@ -91,12 +111,20 @@ func TestResolveWorktreeBase(t *testing.T) {
 			t.Fatalf("InitBare() error = %v", err)
 		}
 
+		var buf bytes.Buffer
+		logger.SetOutput(&buf)
+		defer logger.SetOutput(nil)
+		logger.Init(true, false)
+
 		base, err := ResolveWorktreeBase(bareDir, "", true)
 		if err != nil {
 			t.Fatalf("ResolveWorktreeBase() error = %v", err)
 		}
 		if base != headRef {
 			t.Fatalf("base = %q, want %s", base, headRef)
+		}
+		if buf.String() != "" {
+			t.Fatalf("warning = %q, want none for an empty repository", buf.String())
 		}
 	})
 
@@ -130,12 +158,16 @@ func TestResolveWorktreeBase(t *testing.T) {
 		}
 	})
 
-	t.Run("returns HEAD when no default branch resolves", func(t *testing.T) {
-		t.Parallel()
+	t.Run("warns and returns HEAD when no default branch resolves", func(t *testing.T) {
 		w := testgit.NewGroveWorkspace(t)
 		w.RunOutput("branch", "dev")
 		w.RunOutput("worktree", "remove", "--force", filepath.Join(w.Dir, "main"))
 		w.RunOutput("branch", "-D", "main")
+
+		var buf bytes.Buffer
+		logger.SetOutput(&buf)
+		defer logger.SetOutput(nil)
+		logger.Init(true, false)
 
 		base, err := ResolveWorktreeBase(w.BareDir, "", false)
 		if err != nil {
@@ -143,6 +175,9 @@ func TestResolveWorktreeBase(t *testing.T) {
 		}
 		if base != headRef {
 			t.Fatalf("base = %q, want %s", base, headRef)
+		}
+		if !strings.Contains(buf.String(), "default branch unavailable") {
+			t.Fatalf("warning = %q, want it to name the unavailable default branch", buf.String())
 		}
 	})
 

--- a/internal/git/base_test.go
+++ b/internal/git/base_test.go
@@ -140,6 +140,31 @@ func TestResolveWorktreeBase(t *testing.T) {
 		}
 	})
 
+	t.Run("fetches a qualified base whose tracking ref was pruned", func(t *testing.T) {
+		w := testgit.NewGroveWorkspace(t)
+		origin := testgit.NewTestRepo(t)
+		origin.CreateBranch("develop")
+		w.RunOutput("remote", "add", "origin", origin.Path)
+
+		base, err := ResolveWorktreeBase(w.BareDir, "origin/develop", true)
+		if err != nil {
+			t.Fatalf("ResolveWorktreeBase() error = %v", err)
+		}
+		if base != "origin/develop" {
+			t.Fatalf("base = %q, want origin/develop", base)
+		}
+	})
+
+	t.Run("returns an error for a qualified base origin does not have", func(t *testing.T) {
+		w := testgit.NewGroveWorkspace(t)
+		origin := testgit.NewTestRepo(t)
+		w.RunOutput("remote", "add", "origin", origin.Path)
+
+		if _, err := ResolveWorktreeBase(w.BareDir, "origin/nope", true); err == nil {
+			t.Fatal("expected an error for a base that origin does not have")
+		}
+	})
+
 	t.Run("keeps a local-only base literal", func(t *testing.T) {
 		t.Parallel()
 		w := testgit.NewGroveWorkspace(t)

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -92,6 +92,11 @@ func CreateWorktree(bareRepo, worktreePath string, opts CreateWorktreeOptions, q
 func createWorktreeArgs(worktreePath string, opts CreateWorktreeOptions) []string {
 	args := []string{gitWorktreeSubcommand, "add", "--relative-paths"}
 	if opts.NewBranch {
+		// The base is a start point; branch.autoSetupMerge would otherwise make it an upstream.
+		// An orphan branch has no start point, and git rejects --no-track alongside --orphan.
+		if opts.Base != "" {
+			args = append(args, "--no-track")
+		}
 		args = append(args, "-b", opts.Branch)
 	}
 	if opts.Detach {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -77,10 +77,7 @@ func CreateWorktree(bareRepo, worktreePath string, opts CreateWorktreeOptions, q
 			orphan = true
 		}
 	}
-	args := createWorktreeArgs(worktreePath, opts)
-	if orphan {
-		args = append(args, "--orphan")
-	}
+	args := createWorktreeArgs(worktreePath, opts, orphan)
 	logger.Debug("Executing: git %s", strings.Join(args, " "))
 	cmd, cancel := GitCommand("git", args...)
 	defer cancel()
@@ -89,8 +86,11 @@ func CreateWorktree(bareRepo, worktreePath string, opts CreateWorktreeOptions, q
 	return WrapGitTooOldError(runGitCommand(cmd, quiet))
 }
 
-func createWorktreeArgs(worktreePath string, opts CreateWorktreeOptions) []string {
+func createWorktreeArgs(worktreePath string, opts CreateWorktreeOptions, orphan bool) []string {
 	args := []string{gitWorktreeSubcommand, "add", "--relative-paths"}
+	if orphan {
+		args = append(args, "--orphan")
+	}
 	if opts.NewBranch {
 		// The base is a start point; branch.autoSetupMerge would otherwise make it an upstream.
 		// An orphan branch has no start point, and git rejects --no-track alongside --orphan.

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -69,13 +69,17 @@ func CreateWorktree(bareRepo, worktreePath string, opts CreateWorktreeOptions, q
 		return errors.New("branch name cannot be empty")
 	}
 
-	args := createWorktreeArgs(worktreePath, opts)
 	// An empty repository has no commit to use as a start point.
+	orphan := false
 	if opts.NewBranch && opts.Base == headRef {
 		if unborn, err := isHeadDangling(bareRepo); err == nil && unborn {
 			opts.Base = ""
-			args = append(createWorktreeArgs(worktreePath, opts), "--orphan")
+			orphan = true
 		}
+	}
+	args := createWorktreeArgs(worktreePath, opts)
+	if orphan {
+		args = append(args, "--orphan")
 	}
 	logger.Debug("Executing: git %s", strings.Join(args, " "))
 	cmd, cancel := GitCommand("git", args...)

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -69,10 +69,11 @@ func CreateWorktree(bareRepo, worktreePath string, opts CreateWorktreeOptions, q
 		return errors.New("branch name cannot be empty")
 	}
 
-	// An empty repository has no commit to use as a start point.
+	// An empty repository has no commit to use as a start point. A HEAD that merely
+	// dangles over existing branches is not empty, and git rejects it as a base.
 	orphan := false
 	if opts.NewBranch && opts.Base == headRef {
-		if unborn, err := isHeadDangling(bareRepo); err == nil && unborn {
+		if unborn, err := hasNoBranches(bareRepo); err == nil && unborn {
 			opts.Base = ""
 			orphan = true
 		}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -70,6 +70,13 @@ func CreateWorktree(bareRepo, worktreePath string, opts CreateWorktreeOptions, q
 	}
 
 	args := createWorktreeArgs(worktreePath, opts)
+	// An empty repository has no commit to use as a start point.
+	if opts.NewBranch && opts.Base == headRef {
+		if unborn, err := isHeadDangling(bareRepo); err == nil && unborn {
+			opts.Base = ""
+			args = append(createWorktreeArgs(worktreePath, opts), "--orphan")
+		}
+	}
 	logger.Debug("Executing: git %s", strings.Join(args, " "))
 	cmd, cancel := GitCommand("git", args...)
 	defer cancel()

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -113,7 +113,7 @@ func TestCreateWorktreeArgs(t *testing.T) {
 		{
 			name: "new branch from base",
 			opts: CreateWorktreeOptions{Branch: "feature", NewBranch: true, Base: "main"},
-			want: []string{"worktree", "add", "--relative-paths", "-b", "feature", "/wt", "main"},
+			want: []string{"worktree", "add", "--relative-paths", "--no-track", "-b", "feature", "/wt", "main"},
 		},
 		{
 			name: "detached",

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -884,6 +884,43 @@ func TestCreateWorktreeNewBranch(t *testing.T) {
 }
 
 func TestCreateWorktreeFromBase(t *testing.T) {
+	t.Run("starts an orphan branch in a repository without branches", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := testutil.TempDir(t)
+		bareDir := filepath.Join(tempDir, ".bare")
+		if err := os.MkdirAll(bareDir, fs.DirStrict); err != nil {
+			t.Fatal(err)
+		}
+		if err := InitBare(bareDir); err != nil {
+			t.Fatal(err)
+		}
+
+		worktreeDir := filepath.Join(tempDir, "first")
+		err := CreateWorktree(bareDir, worktreeDir, CreateWorktreeOptions{Branch: "first", NewBranch: true, Base: headRef}, true)
+		if err != nil {
+			t.Fatalf("CreateWorktree() error = %v", err)
+		}
+	})
+
+	t.Run("refuses a base of HEAD when HEAD dangles over an existing branch", func(t *testing.T) {
+		t.Parallel()
+
+		w := testgit.NewGroveWorkspace(t)
+		w.RunOutput("branch", "dev")
+		w.RunOutput("worktree", "remove", "--force", filepath.Join(w.Dir, "main"))
+		w.RunOutput("branch", "-D", "main")
+
+		worktreeDir := filepath.Join(w.Dir, "feature")
+		err := CreateWorktree(w.BareDir, worktreeDir, CreateWorktreeOptions{Branch: "feature", NewBranch: true, Base: headRef}, true)
+		if err == nil {
+			t.Fatal("expected error for a dangling HEAD base")
+		}
+		if _, statErr := os.Stat(worktreeDir); !os.IsNotExist(statErr) {
+			t.Fatalf("worktree should not exist, stat error = %v", statErr)
+		}
+	})
+
 	t.Run("fails with empty bare repo path", func(t *testing.T) {
 		err := CreateWorktree("", "/wt", CreateWorktreeOptions{Branch: "branch", NewBranch: true, Base: "main"}, true)
 		if err == nil {

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -101,10 +101,17 @@ func TestCreateWorktree(t *testing.T) {
 
 func TestCreateWorktreeArgs(t *testing.T) {
 	tests := []struct {
-		name string
-		opts CreateWorktreeOptions
-		want []string
+		name   string
+		opts   CreateWorktreeOptions
+		orphan bool
+		want   []string
 	}{
+		{
+			name:   "orphan branch",
+			opts:   CreateWorktreeOptions{Branch: "first", NewBranch: true},
+			orphan: true,
+			want:   []string{"worktree", "add", "--relative-paths", "--orphan", "-b", "first", "/wt"},
+		},
 		{
 			name: "existing branch",
 			opts: CreateWorktreeOptions{Branch: "main"},
@@ -129,7 +136,7 @@ func TestCreateWorktreeArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := createWorktreeArgs("/wt", tt.opts)
+			got := createWorktreeArgs("/wt", tt.opts, tt.orphan)
 			if !slices.Equal(got, tt.want) {
 				t.Fatalf("createWorktreeArgs() = %q, want %q", got, tt.want)
 			}


### PR DESCRIPTION
**`grove add` now starts a new branch at the remote default branch's tip instead of whatever bare HEAD happens to point at.**

Bare HEAD is only as fresh as the last pull, so a new worktree could silently start days behind. Grove now resolves an explicit base and refreshes it with a short, remote-tracking-only fetch, degrading to local refs with a warning when the network is unavailable. Nothing in an existing worktree is touched: no pull, merge, reset, or checkout anywhere.

#### Changes

- New-branch creation always resolves an explicit start point, then falls back through fetched `origin/<default>` → existing `origin/<default>` → local default branch → bare HEAD, warning once with the base ref and its commit age when it lands below the top rung.
- The fetch writes `+refs/heads/<b>:refs/remotes/origin/<b>` under a five-second budget of its own, independent of `grove.timeout`, so a hanging remote cannot stall `add`. A failure is a warning, never an error.
- `--base <b>` uses `origin/<b>` when a remote counterpart exists; a local-only branch stays literal with no fetch.
- Opt out with `--no-fetch` per invocation, or `grove.fetchBase` / `.grove.toml` `fetch_base` for good; a workspace with no origin, or one with no commits yet, skips the fetch silently.

#### Decisions

- The origin lookup treats an unreadable remote list as "origin present" so a real failure still fetches and still warns; that error branch needs a process-level injection seam to test and is left uncovered.
- New branches are created with `--no-track`, so the fetched base stays a start point and never becomes an upstream; the existing-branch path still sets its own.
- `--base HEAD` resolves the bare repository's HEAD, not the invoking worktree's; the README now says so rather than calling it "local HEAD".

#### Test plan

- [x] Code review by Claude Opus 5 (cape:code-reviewer) on 30d5b41, findings addressed or dismissed
- [x] Code review by GPT-6 Astra (codex) on c9e5316, findings addressed or dismissed
- [x] `make ci` — 1116 tests (320 unit, 796 integration), lint clean
- [x] Stale local `main`: new worktree's commit equals `origin/main`'s tip (`add_fetched_base.txt`)
- [x] Unreachable remote: exit 0, worktree created, one warning naming the base and its age, at each fallback rung (`add_offline_base.txt`)
- [x] Default branch checked out dirty elsewhere: its HEAD, `git status`, and dirty file byte-identical before and after, even with a hostile `remote.origin.fetch` configured (`add_fetched_base.txt`)
- [x] Hung `upload-pack` with `grove.timeout=30s`: `add` returns inside 10s and warns (`add_integration_test.go`)
- [x] `--no-fetch`, `grove.fetchBase=false`, and `.grove.toml` `fetch_base=false` each leave `origin/main` unmoved (`add_no_fetch.txt`)
- [x] A new branch tracks nothing, while an existing remote branch still tracks its counterpart (`add_upstream.txt`)
- [x] No origin, and an empty workspace: no fetch and no warning; a deleted default branch with commits still warns (`add_no_remote.txt`)

---

Fixes ABU-318, AI-132
