### PR TITLE
Release v1.11.0

### DIFF
--- a/.changes/unreleased/changed-rmG3Qolz.yaml
+++ b/.changes/unreleased/changed-rmG3Qolz.yaml
@@ -1,5 +1,0 @@
-kind: Changed
-body: Base new branches on the fetched origin default branch, with offline fallback warnings and fetch opt-outs.
-time: 2026-09-07T17:05:21.627212356+02:00
-custom:
-  Issue: ''

--- a/.changes/unreleased/fixed-IZebvGcN.yaml
+++ b/.changes/unreleased/fixed-IZebvGcN.yaml
@@ -1,5 +1,0 @@
-kind: Fixed
-body: Resolve the default branch from origin/HEAD before bare HEAD, main, and master, checking existing local refs without network access (AI-134).
-time: 2026-09-07T14:29:34.057077769+02:00
-custom:
-  Issue: ''

--- a/.changes/unreleased/fixed-KvecqMyt.yaml
+++ b/.changes/unreleased/fixed-KvecqMyt.yaml
@@ -1,5 +1,0 @@
-kind: Fixed
-body: Link nested directories matched by path patterns such as apps/*/node_modules, using relative symlinks so the links resolve.
-time: 2026-09-07T14:30:31.952371956+02:00
-custom:
-  Issue: ''

--- a/.changes/unreleased/fixed-NvUujvpo.yaml
+++ b/.changes/unreleased/fixed-NvUujvpo.yaml
@@ -1,5 +1,0 @@
-kind: Fixed
-body: Refresh the remote default branch after a successful fetch, keeping refresh failures debug-only (AI-151).
-time: 2026-09-08T08:52:04.889206622+02:00
-custom:
-  Issue: ''

--- a/.changes/unreleased/fixed-WoKuFeW9.yaml
+++ b/.changes/unreleased/fixed-WoKuFeW9.yaml
@@ -1,5 +1,0 @@
-kind: Fixed
-body: Point the bare repository HEAD at the locally resolved default branch after conversion, when that branch exists locally (AI-136).
-time: 2026-09-08T08:44:20.057548951+02:00
-custom:
-  Issue: ''

--- a/.changes/v1.11.0.md
+++ b/.changes/v1.11.0.md
@@ -1,0 +1,10 @@
+## [v1.11.0](https://github.com/sQVe/grove/releases/tag/v1.11.0) - 2026-09-08
+
+### Changed
+- Base new branches on the fetched origin default branch, with offline fallback warnings and fetch opt-outs.
+
+### Fixed
+- Resolve the default branch from origin/HEAD before bare HEAD, main, and master, checking existing local refs without network access (AI-134).
+- Link nested directories matched by path patterns such as apps/*/node_modules, using relative symlinks so the links resolve.
+- Point the bare repository HEAD at the locally resolved default branch after conversion, when that branch exists locally (AI-136).
+- Refresh the remote default branch after a successful fetch, keeping refresh failures debug-only (AI-151).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [v1.11.0](https://github.com/sQVe/grove/releases/tag/v1.11.0) - 2026-09-08
+
+### Changed
+- Base new branches on the fetched origin default branch, with offline fallback warnings and fetch opt-outs.
+
+### Fixed
+- Resolve the default branch from origin/HEAD before bare HEAD, main, and master, checking existing local refs without network access (AI-134).
+- Link nested directories matched by path patterns such as apps/*/node_modules, using relative symlinks so the links resolve.
+- Point the bare repository HEAD at the locally resolved default branch after conversion, when that branch exists locally (AI-136).
+- Refresh the remote default branch after a successful fetch, keeping refresh failures debug-only (AI-151).
+
 ## [v1.10.0](https://github.com/sQVe/grove/releases/tag/v1.10.0) - 2026-09-04
 
 ### Added


### PR DESCRIPTION
This PR was created by the [Changie release GitHub action](https://github.com/labd/changie-release-action). When you're ready to do a release, you can merge this and the tag v1.11.0 will be created.  If you're not ready to do a release yet, that's fine, whenever you add more changes to main, this PR will be updated.

# Releases
## [v1.11.0](https://github.com/sQVe/grove/releases/tag/v1.11.0) - 2026-09-08

### Changed
- Base new branches on the fetched origin default branch, with offline fallback warnings and fetch opt-outs.

### Fixed
- Resolve the default branch from origin/HEAD before bare HEAD, main, and master, checking existing local refs without network access (AI-134).
- Link nested directories matched by path patterns such as apps/*/node_modules, using relative symlinks so the links resolve.
- Point the bare repository HEAD at the locally resolved default branch after conversion, when that branch exists locally (AI-136).
- Refresh the remote default branch after a successful fetch, keeping refresh failures debug-only (AI-151).