### PR TITLE
fix(git): set bare HEAD on init convert and refresh origin/HEAD on fetch

### DIFF
--- a/.changes/unreleased/fixed-NvUujvpo.yaml
+++ b/.changes/unreleased/fixed-NvUujvpo.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Refresh the remote default branch after a successful fetch, keeping refresh failures debug-only (AI-151).
+time: 2026-09-08T08:52:04.889206622+02:00
+custom:
+  Issue: ''

--- a/.changes/unreleased/fixed-WoKuFeW9.yaml
+++ b/.changes/unreleased/fixed-WoKuFeW9.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Point the bare repository HEAD at the locally resolved default branch after conversion, when that branch exists locally.
+time: 2026-09-08T08:44:20.057548951+02:00
+custom:
+  Issue: ''

--- a/.changes/unreleased/fixed-WoKuFeW9.yaml
+++ b/.changes/unreleased/fixed-WoKuFeW9.yaml
@@ -1,5 +1,5 @@
 kind: Fixed
-body: Point the bare repository HEAD at the locally resolved default branch after conversion, when that branch exists locally.
+body: Point the bare repository HEAD at the locally resolved default branch after conversion, when that branch exists locally (AI-136).
 time: 2026-09-08T08:44:20.057548951+02:00
 custom:
   Issue: ''

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -198,6 +198,12 @@ func GetDefaultBranch(bareDir string) (string, error) {
 	cmd.Dir = bareDir
 	output, err := cmd.Output()
 	cancel()
+	// Exit code 1 means origin/HEAD is absent or not symbolic, which is the
+	// expected miss. Anything else is a real failure worth reporting.
+	var exitErr *exec.ExitError
+	if err != nil && (!errors.As(err, &exitErr) || exitErr.ExitCode() != 1) {
+		return "", fmt.Errorf("failed to read origin/HEAD: %w", err)
+	}
 	if err == nil {
 		if branch, ok := strings.CutPrefix(strings.TrimSpace(string(output)), "refs/remotes/origin/"); ok {
 			exists, existsErr := RemoteBranchExists(bareDir, "origin", branch)

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -161,6 +161,10 @@ func GetCurrentBranch(path string) (string, error) {
 // ErrDetachedHead is returned when the worktree is in detached HEAD state
 var ErrDetachedHead = errors.New("detached HEAD state")
 
+// ErrNoDefaultBranch reports that no default branch could be resolved, as
+// distinct from a failure while trying to resolve one.
+var ErrNoDefaultBranch = errors.New("could not determine default branch from HEAD")
+
 // GetCurrentBranchOrDetached returns the branch name, or the short commit hash if detached.
 // Returns (branch, detached, error) where detached indicates if HEAD is detached.
 func GetCurrentBranchOrDetached(path string) (branch string, detached bool, err error) {
@@ -235,7 +239,7 @@ func GetDefaultBranch(bareDir string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("could not determine default branch from HEAD")
+	return "", ErrNoDefaultBranch
 }
 
 // IsUnbornHead checks if the repository has an unborn HEAD (no commits yet).
@@ -607,10 +611,17 @@ func isMergedByPatchID(repoPath, branch, targetBranch string) (bool, error) {
 // the default branch does not resolve or exists only on the remote, since HEAD
 // must never be left dangling.
 func SetHeadToDefaultBranch(bareDir string) error {
+	if bareDir == "" {
+		return errors.New("repository path cannot be empty")
+	}
+
 	defaultBranch, err := GetDefaultBranch(bareDir)
-	if err != nil {
-		logger.Debug("Skipping HEAD update, no default branch resolved: %v", err)
+	if errors.Is(err, ErrNoDefaultBranch) {
+		logger.Debug("Skipping HEAD update, no default branch resolved")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to resolve default branch: %w", err)
 	}
 
 	exists, err := LocalBranchExists(bareDir, defaultBranch)
@@ -622,12 +633,7 @@ func SetHeadToDefaultBranch(bareDir string) error {
 		return nil
 	}
 
-	logger.Debug("Executing: git symbolic-ref HEAD refs/heads/%s in %s", defaultBranch, bareDir)
-	cmd, cancel := GitCommand("git", "symbolic-ref", "HEAD", "refs/heads/"+defaultBranch) // nolint:gosec // Branch resolved from git refs
-	defer cancel()
-	cmd.Dir = bareDir
-
-	if err := runGitCommand(cmd, true); err != nil {
+	if err := SetSymbolicRef(bareDir, "HEAD", "refs/heads/"+defaultBranch); err != nil {
 		return fmt.Errorf("failed to set HEAD to %s: %w", defaultBranch, err)
 	}
 	return nil

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -601,3 +601,34 @@ func isMergedByPatchID(repoPath, branch, targetBranch string) (bool, error) {
 	// All commits marked with "-" means they're all in target (squash-merged)
 	return true, nil
 }
+
+// SetHeadToDefaultBranch points the repository's HEAD at the resolved default
+// branch. It is a local ref write, so it works offline. HEAD is left alone when
+// the default branch does not resolve or exists only on the remote, since HEAD
+// must never be left dangling.
+func SetHeadToDefaultBranch(bareDir string) error {
+	defaultBranch, err := GetDefaultBranch(bareDir)
+	if err != nil {
+		logger.Debug("Skipping HEAD update, no default branch resolved: %v", err)
+		return nil
+	}
+
+	exists, err := LocalBranchExists(bareDir, defaultBranch)
+	if err != nil {
+		return fmt.Errorf("failed to check default branch %s: %w", defaultBranch, err)
+	}
+	if !exists {
+		logger.Debug("Skipping HEAD update, default branch %s has no local ref", defaultBranch)
+		return nil
+	}
+
+	logger.Debug("Executing: git symbolic-ref HEAD refs/heads/%s in %s", defaultBranch, bareDir)
+	cmd, cancel := GitCommand("git", "symbolic-ref", "HEAD", "refs/heads/"+defaultBranch) // nolint:gosec // Branch resolved from git refs
+	defer cancel()
+	cmd.Dir = bareDir
+
+	if err := runGitCommand(cmd, true); err != nil {
+		return fmt.Errorf("failed to set HEAD to %s: %w", defaultBranch, err)
+	}
+	return nil
+}

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -602,7 +602,7 @@ func TestGetDefaultBranch(t *testing.T) {
 
 	t.Run("returns error for missing HEAD", func(t *testing.T) {
 		_, err := GetDefaultBranch(testutil.TempDir(t))
-		if err == nil || !strings.Contains(err.Error(), "failed to read HEAD:") {
+		if err == nil || !strings.Contains(err.Error(), "failed to read") {
 			t.Errorf("expected HEAD read error, got %v", err)
 		}
 	})

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -574,7 +575,7 @@ func TestGetDefaultBranch(t *testing.T) {
 			t.Setenv("GIT_ALLOW_PROTOCOL", "")
 			branch, err := GetDefaultBranch(bareDir)
 			if tt.want == "" {
-				if err == nil || err.Error() != "could not determine default branch from HEAD" {
+				if !errors.Is(err, ErrNoDefaultBranch) {
 					t.Errorf("expected unresolved default branch error, got %v", err)
 				}
 			} else if err != nil {

--- a/internal/git/fetch.go
+++ b/internal/git/fetch.go
@@ -132,7 +132,18 @@ func FetchRemote(repoPath, remote string) error {
 	defer cancel()
 	cmd.Dir = repoPath
 
-	return runGitCommand(cmd, true)
+	if err := runGitCommand(cmd, true); err != nil {
+		return err
+	}
+
+	logger.Debug("Executing: git remote set-head %s --auto in %s", remote, repoPath)
+	cmd, cancel = GitCommand("git", "remote", "set-head", remote, "--auto") //nolint:gosec
+	defer cancel()
+	cmd.Dir = repoPath
+	if err := runGitCommand(cmd, true); err != nil {
+		logger.Debug("Failed to refresh %s/HEAD: %v", remote, err)
+	}
+	return nil
 }
 
 func CountCommits(repoPath, fromHash, toHash string) int {

--- a/internal/git/fetch.go
+++ b/internal/git/fetch.go
@@ -107,7 +107,9 @@ func GetRemoteRefs(repoPath, remote string) (map[string]string, error) {
 		}
 
 		parts := strings.Fields(line)
-		if len(parts) == 2 {
+		// <remote>/HEAD is a symbolic alias, so reporting it would double-count
+		// the branch it points at.
+		if len(parts) == 2 && parts[0] != refPattern+"HEAD" {
 			refs[parts[0]] = parts[1]
 		}
 	}

--- a/internal/git/fetch_test.go
+++ b/internal/git/fetch_test.go
@@ -1,9 +1,14 @@
 package git
 
 import (
+	"bytes"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/sqve/grove/internal/logger"
 	testgit "github.com/sqve/grove/internal/testutil/git"
 )
 
@@ -180,6 +185,84 @@ func TestGetRemoteRefs(t *testing.T) {
 }
 
 func TestFetchRemote(t *testing.T) {
+	newRemoteFixture := func(t *testing.T) (*testgit.BareTestRepo, *testgit.BareTestRepo) {
+		t.Helper()
+		seed := testgit.NewTestRepo(t)
+		remote := testgit.NewBareTestRepo(t)
+		seed.RunOutput("push", remote.Path, "main")
+		repo := testgit.NewBareTestRepo(t)
+		repo.RunOutput("remote", "add", "origin", remote.Path)
+		repo.RunOutput("config", "remote.origin.followRemoteHEAD", "never")
+		repo.RunOutput("fetch", "origin")
+		repo.RunOutput("symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+		return repo, remote
+	}
+
+	t.Run("preserves the remote HEAD and error when fetching fails", func(t *testing.T) {
+		repo, _ := newRemoteFixture(t)
+		headPath := filepath.Join(repo.Path, "refs", "remotes", "origin", "HEAD")
+		before, err := os.ReadFile(headPath) //nolint:gosec // Path belongs to the local test fixture.
+		if err != nil {
+			t.Fatal(err)
+		}
+		repo.RunOutput("remote", "set-url", "origin", filepath.Join(t.TempDir(), "missing.git"))
+		cmd := exec.Command("git", "fetch", "--prune", "origin")
+		cmd.Dir = repo.Path
+		wantErr := runGitCommand(cmd, true)
+		if wantErr == nil {
+			t.Fatal("fetch from missing remote succeeded")
+		}
+
+		if err := FetchRemote(repo.Path, "origin"); err == nil || err.Error() != wantErr.Error() {
+			t.Fatalf("FetchRemote() error = %v, want %v", err, wantErr)
+		}
+		after, err := os.ReadFile(headPath) //nolint:gosec // Path belongs to the local test fixture.
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(before, after) {
+			t.Fatalf("origin/HEAD changed from %q to %q", before, after)
+		}
+	})
+
+	t.Run("logs a set-head failure only in debug mode after fetching", func(t *testing.T) {
+		repo, remote := newRemoteFixture(t)
+		remote.RunOutput("branch", "feature")
+		remote.RunOutput("symbolic-ref", "HEAD", "refs/heads/missing")
+		var logs bytes.Buffer
+		previous := logger.SetOutput(&logs)
+		defer logger.SetOutput(previous)
+		defer logger.Init(false, false)
+
+		for _, debug := range []bool{true, false} {
+			logger.Init(true, debug)
+			logs.Reset()
+			if err := FetchRemote(repo.Path, "origin"); err != nil {
+				t.Fatalf("FetchRemote() error = %v, want nil", err)
+			}
+			if debug && !strings.Contains(logs.String(), "[DEBUG] Failed to refresh origin/HEAD:") {
+				t.Errorf("missing set-head failure debug log: %q", logs.String())
+			}
+			if !debug && logs.Len() != 0 {
+				t.Errorf("unexpected non-debug output: %q", logs.String())
+			}
+		}
+		repo.RunOutput("rev-parse", "--verify", "refs/remotes/origin/feature")
+	})
+
+	t.Run("refreshes the remote default branch after fetching", func(t *testing.T) {
+		repo, remote := newRemoteFixture(t)
+		remote.RunOutput("branch", "develop")
+		remote.RunOutput("symbolic-ref", "HEAD", "refs/heads/develop")
+
+		if err := FetchRemote(repo.Path, "origin"); err != nil {
+			t.Fatalf("FetchRemote() error = %v", err)
+		}
+		if got := repo.RunOutput("symbolic-ref", "refs/remotes/origin/HEAD"); got != "refs/remotes/origin/develop\n" {
+			t.Fatalf("origin/HEAD = %q, want refs/remotes/origin/develop", got)
+		}
+	})
+
 	t.Run("successful fetch", func(t *testing.T) {
 		repo := testgit.NewTestRepo(t)
 

--- a/internal/git/fetch_test.go
+++ b/internal/git/fetch_test.go
@@ -229,6 +229,11 @@ func TestFetchRemote(t *testing.T) {
 		repo, remote := newRemoteFixture(t)
 		remote.RunOutput("branch", "feature")
 		remote.RunOutput("symbolic-ref", "HEAD", "refs/heads/missing")
+		headPath := filepath.Join(repo.Path, "refs", "remotes", "origin", "HEAD")
+		before, err := os.ReadFile(headPath) //nolint:gosec // Path belongs to the local test fixture.
+		if err != nil {
+			t.Fatal(err)
+		}
 		var logs bytes.Buffer
 		previous := logger.SetOutput(&logs)
 		defer logger.SetOutput(previous)
@@ -248,6 +253,13 @@ func TestFetchRemote(t *testing.T) {
 			}
 		}
 		repo.RunOutput("rev-parse", "--verify", "refs/remotes/origin/feature")
+		after, err := os.ReadFile(headPath) //nolint:gosec // Path belongs to the local test fixture.
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(before, after) {
+			t.Fatalf("origin/HEAD changed from %q to %q", before, after)
+		}
 	})
 
 	t.Run("refreshes the remote default branch after fetching", func(t *testing.T) {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -965,20 +965,22 @@ func Convert(targetDir, branches string, verbose bool) error {
 		return fmt.Errorf("failed to create .git file: %w", err)
 	}
 
+	// HEAD is cosmetic next to a completed conversion, so failures warn instead
+	// of rolling the whole conversion back.
 	bareDir := filepath.Join(targetDir, ".bare")
 	if defaultBranch, err := git.GetDefaultBranch(bareDir); err == nil {
 		// The resolver can return a remote-only branch; HEAD needs a local ref.
 		exists, err := git.LocalBranchExists(bareDir, defaultBranch)
-		if err != nil {
-			return fmt.Errorf("failed to check default branch: %w", err)
-		}
-		if exists {
+		switch {
+		case err != nil:
+			logger.Warning("Failed to check default branch %s: %v", defaultBranch, err)
+		case exists:
 			cmd, cancel := git.GitCommand("git", "symbolic-ref", "HEAD", "refs/heads/"+defaultBranch) // nolint:gosec // Branch resolved from git refs
-			defer cancel()
 			cmd.Dir = bareDir
 			if err := cmd.Run(); err != nil {
-				return fmt.Errorf("failed to set bare HEAD: %w", err)
+				logger.Warning("Failed to set bare HEAD to %s: %v", defaultBranch, err)
 			}
+			cancel()
 		}
 	}
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -967,21 +967,8 @@ func Convert(targetDir, branches string, verbose bool) error {
 
 	// HEAD is cosmetic next to a completed conversion, so failures warn instead
 	// of rolling the whole conversion back.
-	bareDir := filepath.Join(targetDir, ".bare")
-	if defaultBranch, err := git.GetDefaultBranch(bareDir); err == nil {
-		// The resolver can return a remote-only branch; HEAD needs a local ref.
-		exists, err := git.LocalBranchExists(bareDir, defaultBranch)
-		switch {
-		case err != nil:
-			logger.Warning("Failed to check default branch %s: %v", defaultBranch, err)
-		case exists:
-			cmd, cancel := git.GitCommand("git", "symbolic-ref", "HEAD", "refs/heads/"+defaultBranch) // nolint:gosec // Branch resolved from git refs
-			cmd.Dir = bareDir
-			if err := cmd.Run(); err != nil {
-				logger.Warning("Failed to set bare HEAD to %s: %v", defaultBranch, err)
-			}
-			cancel()
-		}
+	if err := git.SetHeadToDefaultBranch(filepath.Join(targetDir, ".bare")); err != nil {
+		logger.Warning("Failed to set bare HEAD: %v", err)
 	}
 
 	conversionSucceeded = true

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -965,6 +965,23 @@ func Convert(targetDir, branches string, verbose bool) error {
 		return fmt.Errorf("failed to create .git file: %w", err)
 	}
 
+	bareDir := filepath.Join(targetDir, ".bare")
+	if defaultBranch, err := git.GetDefaultBranch(bareDir); err == nil {
+		// The resolver can return a remote-only branch; HEAD needs a local ref.
+		exists, err := git.LocalBranchExists(bareDir, defaultBranch)
+		if err != nil {
+			return fmt.Errorf("failed to check default branch: %w", err)
+		}
+		if exists {
+			cmd, cancel := git.GitCommand("git", "symbolic-ref", "HEAD", "refs/heads/"+defaultBranch) // nolint:gosec // Branch resolved from git refs
+			defer cancel()
+			cmd.Dir = bareDir
+			if err := cmd.Run(); err != nil {
+				return fmt.Errorf("failed to set bare HEAD: %w", err)
+			}
+		}
+	}
+
 	conversionSucceeded = true
 	return nil
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -16,6 +16,57 @@ import (
 
 const testEnvFile = ".env"
 
+func TestConvertHead(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "")
+
+	for _, remoteOnly := range []bool{false, true} {
+		name := "preserves HEAD without a remote"
+		if remoteOnly {
+			name = "preserves HEAD when the default branch exists only remotely"
+		}
+		t.Run(name, func(t *testing.T) {
+			repo := testgit.NewTestRepo(t, "feature")
+			if remoteOnly {
+				repo.AddRemote("origin", "https://example.invalid/repo.git")
+				repo.RunOutput("update-ref", "refs/remotes/origin/develop", "HEAD")
+				repo.RunOutput("symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/develop")
+			}
+
+			if err := Convert(repo.Path, "", false); err != nil {
+				t.Fatal(err)
+			}
+
+			bareDir := filepath.Join(repo.Path, ".bare")
+			if got := strings.TrimSpace(repo.RunOutput("--git-dir", bareDir, "symbolic-ref", "HEAD")); got != "refs/heads/feature" {
+				t.Errorf("expected bare HEAD to stay on feature, got %q", got)
+			}
+			repo.RunOutput("--git-dir", bareDir, "rev-parse", "--verify", "HEAD")
+		})
+	}
+
+	t.Run("points bare HEAD at the resolved default branch", func(t *testing.T) {
+		repo := testgit.NewTestRepo(t, "develop")
+		repo.AddRemote("origin", "https://example.invalid/repo.git")
+		repo.RunOutput("update-ref", "refs/remotes/origin/develop", "HEAD")
+		repo.RunOutput("symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/develop")
+		repo.CreateBranch("feature")
+		repo.Checkout("feature")
+
+		if err := Convert(repo.Path, "", false); err != nil {
+			t.Fatal(err)
+		}
+
+		bareDir := filepath.Join(repo.Path, ".bare")
+		if got := strings.TrimSpace(repo.RunOutput("--git-dir", bareDir, "symbolic-ref", "HEAD")); got != "refs/heads/develop" {
+			t.Errorf("expected bare HEAD to point at develop, got %q", got)
+		}
+		repo.RunOutput("--git-dir", bareDir, "rev-parse", "--verify", "HEAD")
+		if got := strings.TrimSpace(repo.RunOutput("-C", "feature", "symbolic-ref", "HEAD")); got != "refs/heads/feature" {
+			t.Errorf("expected worktree HEAD to stay on feature, got %q", got)
+		}
+	})
+}
+
 func TestConvert(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**A converted workspace now starts with its bare HEAD on the default branch, and `origin/HEAD` is refreshed on every successful fetch.**

`grove init convert` never set the bare repository's HEAD, so conversion froze whatever branch happened to be checked out at the time — one workspace sat on a feature branch for five months. `origin/HEAD` had the same problem from the other side: it was written at clone time and never revisited, so it rotted whenever the remote's default branch moved. Both are now repaired at the moment the information is available, and both repairs are fail-soft: they never undo the operation they were attached to, and never destroy the value they failed to improve.

#### Changes

- Conversion ends by pointing the bare repository's HEAD at the resolved default branch, using the existing resolver. HEAD is left alone when nothing resolves or when the default branch has no local ref, so it is never left dangling.
- The HEAD write is local only, so conversion stays offline-capable, and a failure warns rather than rolling back an otherwise complete conversion.
- A successful `grove fetch` follows up with `git remote set-head <remote> --auto`. It runs only after the fetch itself succeeds, and its own failure is debug-logged, so an unreachable remote leaves the existing `origin/HEAD` byte-identical and reports the fetch failure exactly as before.
- The fetch report no longer lists the symbolic `<remote>/HEAD` ref, which would otherwise appear as a second change alongside the branch it aliases.
- A sentinel separates "no default branch could be resolved" from "resolving one failed", so a broken ref read surfaces instead of being swallowed.

#### Test plan

- [x] Code review by Claude Opus 5 (cape:code-reviewer) on fe4459d, findings addressed or dismissed
- [x] `make ci` passes
- [x] Converting a repo checked out on a feature branch leaves bare HEAD on the default branch, worktree untouched
- [x] Converting with no remote, and with the default branch remote-only, leaves HEAD valid and non-dangling with no network access
- [x] Fetching after the remote's default branch moves updates `refs/remotes/origin/HEAD`
- [x] Fetching from an unreachable remote leaves `origin/HEAD` byte-identical and returns the same error as a raw `git fetch --prune`

---

Fixes ABU-319, AI-133