### PR TITLE
fix(add): fetch an explicit --base before reporting it missing

### DIFF
--- a/.changes/unreleased/fixed-AI-148.yaml
+++ b/.changes/unreleased/fixed-AI-148.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fetch an explicit unqualified `grove add --base` branch before reporting it missing, and prefer its origin ref over a stale local branch.
+time: 2026-09-08T11:17:49+02:00

--- a/README.md
+++ b/README.md
@@ -223,8 +223,11 @@ grove add --from dev feat/auth # Copy .env from dev worktree
 New branches start from the default branch on origin, fetched with a five-second timeout.
 If fetching fails, Grove warns with the base ref and commit age, then uses the existing
 origin ref, local default branch, or bare HEAD. Local branches and worktrees stay unchanged.
-An explicit `--base` uses its origin counterpart when available, and `--base HEAD` selects
-the bare repository's HEAD. Use `--no-fetch` to skip fetching once, or
+An explicit `--base <branch>` fetches the branch from origin before resolving it, even
+when its remote-tracking ref is missing. It prefers `origin/<branch>`, falls back to the
+local branch, and errors if neither exists. `--base origin/<branch>` requires the origin
+ref. `--base HEAD` selects the bare repository's HEAD without fetching.
+Use `--no-fetch` to skip fetching once, or
 `grove config set --global grove.fetchBase false` to disable it by default. Both leave the
 refs on disk untouched and pick from them in the same order.
 

--- a/cmd/grove/testdata/script/add_explicit_remote_base.txt
+++ b/cmd/grove/testdata/script/add_explicit_remote_base.txt
@@ -20,11 +20,11 @@ cmp stdout $WORK/expected
 ! exec grove add --base origin/nope from-missing
 stderr 'base branch "origin/nope" does not exist'
 
-# A local-only base remains literal and never contacts origin.
+# A local-only base remains usable when fetching fails.
 exec git branch local-only
 exec git remote set-url origin $WORK/missing
 exec grove add --base local-only from-local
-! stderr 'fetch failed'
+stderr 'basing on local-only from .* - fetch failed'
 exec git rev-parse local-only
 cp stdout $WORK/local
 exec git -C ../from-local rev-parse HEAD

--- a/cmd/grove/testdata/script/add_explicit_remote_base.txt
+++ b/cmd/grove/testdata/script/add_explicit_remote_base.txt
@@ -20,11 +20,10 @@ cmp stdout $WORK/expected
 ! exec grove add --base origin/nope from-missing
 stderr 'base branch "origin/nope" does not exist'
 
-# A local-only base remains usable when fetching fails.
+# An unpushed local-only base does not produce a fetch failure warning.
 exec git branch local-only
-exec git remote set-url origin $WORK/missing
 exec grove add --base local-only from-local
-stderr 'basing on local-only from .* - fetch failed'
+! stderr 'fetch failed'
 exec git rev-parse local-only
 cp stdout $WORK/local
 exec git -C ../from-local rev-parse HEAD

--- a/cmd/grove/testdata/script/add_no_fetch.txt
+++ b/cmd/grove/testdata/script/add_no_fetch.txt
@@ -14,6 +14,18 @@ cmp stdout $WORK/before
 exec git -C ../flag-skipped rev-parse HEAD
 cmp stdout $WORK/before
 
+# An unfetched explicit base uses only refs on disk with --no-fetch.
+exec git -C $WORK/testrepo branch develop
+! exec grove add --no-fetch --base develop missing-base
+stderr 'base branch "develop" does not exist'
+! exec git rev-parse --verify refs/remotes/origin/develop
+exec git branch develop
+exec grove add --no-fetch --base develop local-base
+! stderr 'fetch failed'
+! exec git rev-parse --verify refs/remotes/origin/develop
+exec git -C ../local-base rev-parse HEAD
+cmp stdout $WORK/before
+
 exec grove config set --global grove.fetchBase false
 exec grove config list
 stdout 'fetch_base=false'

--- a/internal/git/base.go
+++ b/internal/git/base.go
@@ -19,12 +19,16 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 	qualified := strings.HasPrefix(base, "origin/")
 	explicit := base != ""
 	if explicit {
-		remote, err := RemoteBranchExists(bareDir, "origin", branch)
-		if err != nil {
-			return "", fmt.Errorf("failed to check origin/%s: %w", branch, err)
+		localOnly := false
+		if !fetch && !qualified {
+			remote, err := RemoteBranchExists(bareDir, "origin", branch)
+			if err != nil {
+				return "", fmt.Errorf("failed to check origin/%s: %w", branch, err)
+			}
+			localOnly = !remote
 		}
 		// Fetch an explicit base before calling it missing, unless fetching is disabled.
-		if (!fetch && !remote && !qualified) || base == headRef {
+		if localOnly || base == headRef {
 			// An empty repository has no ref to verify; CreateWorktree starts an orphan branch.
 			if base == headRef {
 				empty, emptyErr := hasNoBranches(bareDir)
@@ -84,7 +88,10 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 	}
 	if fetchErr != nil {
 		logger.Debug("Base fetch failed: %v", fetchErr)
-		warnWorktreeBase(bareDir, base, "fetch failed")
+		// An unpushed local branch is usable without a counterpart on origin.
+		if !local || remote || !strings.HasSuffix(fetchErr.Error(), "fatal: couldn't find remote ref refs/heads/"+branch) {
+			warnWorktreeBase(bareDir, base, "fetch failed")
+		}
 	}
 	return base, nil
 }

--- a/internal/git/base.go
+++ b/internal/git/base.go
@@ -79,6 +79,11 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 	if localErr != nil {
 		return "", fmt.Errorf("failed to check branch %s: %w", branch, localErr)
 	}
+	missingRef := fetchErr != nil && strings.HasSuffix(fetchErr.Error(), "fatal: couldn't find remote ref refs/heads/"+branch)
+	// A failed fetch is no proof the branch is missing, so report the failure instead.
+	if explicit && fetchErr != nil && !missingRef && !remote && !local {
+		return "", fmt.Errorf("failed to fetch base branch %q: %w", branch, fetchErr)
+	}
 	switch {
 	case remote:
 		base = "origin/" + branch
@@ -92,7 +97,7 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 	if fetchErr != nil {
 		logger.Debug("Base fetch failed: %v", fetchErr)
 		// An unpushed local branch is usable without a counterpart on origin.
-		if !local || remote || !strings.HasSuffix(fetchErr.Error(), "fatal: couldn't find remote ref refs/heads/"+branch) {
+		if !explicit || !local || remote || !missingRef {
 			warnWorktreeBase(bareDir, base, "fetch failed")
 		}
 	}

--- a/internal/git/base.go
+++ b/internal/git/base.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -63,6 +64,8 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 			defer cancel()
 			cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", "--refmap=", "origin", "+refs/heads/"+branch+":refs/remotes/origin/"+branch) //nolint:gosec // Fixed executable; branch is part of one refspec argument, not shell input.
 			cmd.Dir = bareDir
+			// The missing-ref message is matched below, so keep git's output untranslated.
+			cmd.Env = append(os.Environ(), "LC_ALL=C")
 			cmd.WaitDelay = time.Second
 			fetchErr = runGitCommand(cmd, true)
 		}

--- a/internal/git/base.go
+++ b/internal/git/base.go
@@ -17,13 +17,14 @@ const headRef = "HEAD"
 func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 	branch := strings.TrimPrefix(base, "origin/")
 	qualified := strings.HasPrefix(base, "origin/")
-	if base != "" {
+	explicit := base != ""
+	if explicit {
 		remote, err := RemoteBranchExists(bareDir, "origin", branch)
 		if err != nil {
 			return "", fmt.Errorf("failed to check origin/%s: %w", branch, err)
 		}
-		// A qualified base names a remote branch, so fetch it before calling it missing.
-		if (!remote && !qualified) || base == headRef {
+		// Fetch an explicit base before calling it missing, unless fetching is disabled.
+		if (!fetch && !remote && !qualified) || base == headRef {
 			// An empty repository has no ref to verify; CreateWorktree starts an orphan branch.
 			if base == headRef {
 				empty, emptyErr := hasNoBranches(bareDir)
@@ -56,7 +57,7 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 		if hasOrigin, originErr := RemoteExists(bareDir, "origin"); originErr != nil || hasOrigin {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", "--refmap=", "origin", "+refs/heads/"+branch+":refs/remotes/origin/"+branch) //nolint:gosec // Branch resolved from git
+			cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", "--refmap=", "origin", "+refs/heads/"+branch+":refs/remotes/origin/"+branch) //nolint:gosec // Fixed executable; branch is part of one refspec argument, not shell input.
 			cmd.Dir = bareDir
 			cmd.WaitDelay = time.Second
 			fetchErr = runGitCommand(cmd, true)
@@ -78,6 +79,8 @@ func ResolveWorktreeBase(bareDir, base string, fetch bool) (string, error) {
 		return "", fmt.Errorf("base branch \"origin/%s\" does not exist", branch)
 	case local:
 		base = branch
+	case explicit:
+		return "", fmt.Errorf("base branch %q does not exist", branch)
 	}
 	if fetchErr != nil {
 		logger.Debug("Base fetch failed: %v", fetchErr)

--- a/internal/git/base_test.go
+++ b/internal/git/base_test.go
@@ -210,10 +210,16 @@ func TestResolveWorktreeBase(t *testing.T) {
 		}
 	})
 
-	t.Run("keeps a local-only base literal", func(t *testing.T) {
-		t.Parallel()
+	t.Run("keeps a local-only base literal without a fetch failure warning", func(t *testing.T) {
 		w := testgit.NewGroveWorkspace(t)
+		origin := testgit.NewTestRepo(t)
+		w.RunOutput("remote", "add", "origin", origin.Path)
 		w.RunOutput("branch", "local-only")
+
+		var buf bytes.Buffer
+		logger.SetOutput(&buf)
+		defer logger.SetOutput(nil)
+		logger.Init(true, false)
 
 		base, err := ResolveWorktreeBase(w.BareDir, "local-only", true)
 		if err != nil {
@@ -221,6 +227,32 @@ func TestResolveWorktreeBase(t *testing.T) {
 		}
 		if base != "local-only" {
 			t.Fatalf("base = %q, want local-only", base)
+		}
+		if strings.Contains(buf.String(), "fetch failed") {
+			t.Fatalf("unexpected fetch failure warning: %s", buf.String())
+		}
+	})
+
+	t.Run("checks the remote-tracking ref only after fetching", func(t *testing.T) {
+		w := testgit.NewGroveWorkspace(t)
+		origin := testgit.NewTestRepo(t)
+		w.RunOutput("remote", "add", "origin", origin.Path)
+		trace := filepath.Join(testutil.TempDir(t), "git-trace")
+		t.Setenv("GIT_TRACE", trace)
+
+		base, err := ResolveWorktreeBase(w.BareDir, "main", true)
+		if err != nil {
+			t.Fatalf("ResolveWorktreeBase() error = %v", err)
+		}
+		if base != "origin/main" {
+			t.Fatalf("base = %q, want origin/main", base)
+		}
+		output, err := os.ReadFile(trace) //nolint:gosec // Trace path is inside the test's temporary directory.
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count := strings.Count(string(output), "git show-ref --verify --quiet refs/remotes/origin/main"); count != 1 {
+			t.Fatalf("remote-tracking ref checks = %d, want 1\n%s", count, output)
 		}
 	})
 

--- a/internal/git/base_test.go
+++ b/internal/git/base_test.go
@@ -233,6 +233,41 @@ func TestResolveWorktreeBase(t *testing.T) {
 		}
 	})
 
+	t.Run("warns when the default base fetch fails and only a local branch exists", func(t *testing.T) {
+		w := testgit.NewGroveWorkspace(t)
+		origin := testgit.NewTestRepo(t, "trunk")
+		w.RunOutput("remote", "add", "origin", origin.Path)
+
+		var buf bytes.Buffer
+		logger.SetOutput(&buf)
+		defer logger.SetOutput(nil)
+		logger.Init(true, false)
+
+		base, err := ResolveWorktreeBase(w.BareDir, "", true)
+		if err != nil {
+			t.Fatalf("ResolveWorktreeBase() error = %v", err)
+		}
+		if base != "main" {
+			t.Fatalf("base = %q, want main", base)
+		}
+		if !strings.Contains(buf.String(), "fetch failed") {
+			t.Fatalf("warning = %q, want a fetch failure warning for the default base", buf.String())
+		}
+	})
+
+	t.Run("surfaces a failed fetch instead of calling an explicit base missing", func(t *testing.T) {
+		w := testgit.NewGroveWorkspace(t)
+		w.RunOutput("remote", "add", "origin", filepath.Join(testutil.TempDir(t), "gone"))
+
+		_, err := ResolveWorktreeBase(w.BareDir, "develop", true)
+		if err == nil {
+			t.Fatal("expected an error when the base fetch fails")
+		}
+		if strings.Contains(err.Error(), "does not exist") {
+			t.Fatalf("error = %v, want it to report the fetch failure, not a missing branch", err)
+		}
+	})
+
 	t.Run("checks the remote-tracking ref only after fetching", func(t *testing.T) {
 		w := testgit.NewGroveWorkspace(t)
 		origin := testgit.NewTestRepo(t)

--- a/internal/git/base_test.go
+++ b/internal/git/base_test.go
@@ -155,6 +155,51 @@ func TestResolveWorktreeBase(t *testing.T) {
 		}
 	})
 
+	for _, staleLocal := range []bool{false, true} {
+		name := "fetches an unqualified base whose tracking ref was pruned"
+		if staleLocal {
+			name = "prefers fetched unqualified base over stale local branch"
+		}
+		t.Run(name, func(t *testing.T) {
+			w := testgit.NewGroveWorkspace(t)
+			origin := testgit.NewTestRepo(t)
+			origin.CreateBranch("develop")
+			w.RunOutput("remote", "add", "origin", origin.Path)
+			w.RunOutput("fetch", "origin", "+refs/heads/develop:refs/remotes/origin/develop")
+			before := w.RunOutput("rev-parse", "origin/develop")
+			if staleLocal {
+				w.RunOutput("branch", "develop", "origin/develop")
+			}
+			w.RunOutput("update-ref", "-d", "refs/remotes/origin/develop")
+			origin.RunOutput("checkout", "develop")
+			origin.RunOutput("commit", "--allow-empty", "-m", "upstream")
+
+			base, err := ResolveWorktreeBase(w.BareDir, "develop", true)
+			if err != nil {
+				t.Fatalf("ResolveWorktreeBase() error = %v", err)
+			}
+			if base != "origin/develop" {
+				t.Fatalf("base = %q, want origin/develop", base)
+			}
+			if got := w.RunOutput("rev-parse", base); got == before {
+				t.Fatal("base still points at the stale commit")
+			}
+			if staleLocal && w.RunOutput("rev-parse", "develop") != before {
+				t.Fatal("fetch changed the local branch")
+			}
+		})
+	}
+
+	t.Run("returns an error for an unqualified base origin does not have", func(t *testing.T) {
+		w := testgit.NewGroveWorkspace(t)
+		origin := testgit.NewTestRepo(t)
+		w.RunOutput("remote", "add", "origin", origin.Path)
+
+		if _, err := ResolveWorktreeBase(w.BareDir, "nope", true); err == nil || err.Error() != `base branch "nope" does not exist` {
+			t.Fatalf("error = %v, want missing-branch error", err)
+		}
+	})
+
 	t.Run("returns an error for a qualified base origin does not have", func(t *testing.T) {
 		w := testgit.NewGroveWorkspace(t)
 		origin := testgit.NewTestRepo(t)


### PR DESCRIPTION
**`grove add --base <branch>` now fetches an explicit base from origin before deciding it does not exist.**

An unqualified `--base` returned before the fetch block, so a branch that lived only on origin — or whose remote-tracking ref had been pruned — read as missing, and a stale local branch of the same name won over the newer origin one. The explicit base now takes the same fetch-then-prefer-origin path the `origin/<branch>` form already used, and a base absent from both sides errors instead of silently falling back to HEAD.

#### Changes

- An unqualified `--base <branch>` falls through to the shared fetch when fetching is enabled, prefers `origin/<branch>`, falls back to the local branch, and errors with `base branch "<branch>" does not exist` when neither side has it.
- `--base HEAD`, `--base origin/<branch>`, `--no-fetch`, and `grove.fetchBase false` are unchanged, and the five-second budget and remote-tracking-only refspec still hold.
- An unpushed local-only base no longer prints a misleading `fetch failed` warning, and no longer pays a redundant origin check; genuine fetch failures and timeouts still warn with the base and commit age.
- The README base-resolution paragraph now describes the actual resolution order.

#### Decisions

- The suppressed warning is recognised by git's missing-ref message, so the fetch runs under `LC_ALL=C`; if a future git ever rewords it, the warning simply returns rather than misfiring.

#### Test plan

- [x] Code review by Claude Opus 5 (cape:code-reviewer) on a73e566, findings addressed or dismissed
- [x] `make ci` passes
- [x] `LC_ALL=sv_SE.utf8 go test ./internal/git/ -run TestResolveWorktreeBase -count=1` passes
- [x] `grove add --base develop` bases on the fetched `origin/develop` in a workspace whose tracking ref was pruned

---

Fixes ABU-348, AI-147