### PR TITLE
Release v1.11.1

### DIFF
--- a/.changes/unreleased/fixed-AI-148.yaml
+++ b/.changes/unreleased/fixed-AI-148.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: Fetch an explicit unqualified `grove add --base` branch before reporting it missing, and prefer its origin ref over a stale local branch.
-time: 2026-09-08T11:17:49+02:00

--- a/.changes/v1.11.1.md
+++ b/.changes/v1.11.1.md
@@ -1,0 +1,4 @@
+## [v1.11.1](https://github.com/sQVe/grove/releases/tag/v1.11.1) - 2026-09-08
+
+### Fixed
+- Fetch an explicit unqualified `grove add --base` branch before reporting it missing, and prefer its origin ref over a stale local branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [v1.11.1](https://github.com/sQVe/grove/releases/tag/v1.11.1) - 2026-09-08
+
+### Fixed
+- Fetch an explicit unqualified `grove add --base` branch before reporting it missing, and prefer its origin ref over a stale local branch.
+
 ## [v1.11.0](https://github.com/sQVe/grove/releases/tag/v1.11.0) - 2026-09-08
 
 ### Changed


### PR DESCRIPTION
This PR was created by the [Changie release GitHub action](https://github.com/labd/changie-release-action). When you're ready to do a release, you can merge this and the tag v1.11.1 will be created.  If you're not ready to do a release yet, that's fine, whenever you add more changes to main, this PR will be updated.

# Releases
## [v1.11.1](https://github.com/sQVe/grove/releases/tag/v1.11.1) - 2026-09-08

### Fixed
- Fetch an explicit unqualified `grove add --base` branch before reporting it missing, and prefer its origin ref over a stale local branch.