### PR TITLE
feat(add): make grove add re-runnable and fast-forward stale branches

### DIFF
--- a/.changes/unreleased/added-AI-153.yaml
+++ b/.changes/unreleased/added-AI-153.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: '`grove add` fast-forwards a strictly-behind local branch before creating its worktree.'
+time: 2026-09-08T15:00:00+02:00

--- a/.changes/unreleased/added-AI-153.yaml
+++ b/.changes/unreleased/added-AI-153.yaml
@@ -1,3 +1,3 @@
 kind: Added
 body: '`grove add` fast-forwards a strictly-behind local branch before creating its worktree.'
-time: 2026-09-08T15:00:00+02:00
+time: 2026-09-08T14:48:11+02:00

--- a/.changes/unreleased/added-AI-154.yaml
+++ b/.changes/unreleased/added-AI-154.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'Re-running `grove add --pr` refreshes the existing same-repo worktree: fast-forwards, supports `--reset` on divergence, and refuses uncommitted tracked changes.'
+time: 2026-09-08T16:00:00+02:00

--- a/.changes/unreleased/added-AI-88.yaml
+++ b/.changes/unreleased/added-AI-88.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: '`grove add -s` switches to an existing worktree instead of erroring.'
+time: 2026-09-08T14:31:05+02:00

--- a/README.md
+++ b/README.md
@@ -234,10 +234,10 @@ refs on disk untouched and pick from them in the same order.
 Adding an existing local branch fetches its upstream (`origin/<branch>` when none is
 configured) and fast-forwards the branch first when it is strictly behind; a branch that is
 ahead or diverged is checked out as is. `--no-fetch` skips that fetch too. Re-running
-`grove add --pr N` on a PR that already has a worktree refreshes it: a clean worktree is
-fast-forwarded, a branch with local commits errors unless `--reset` discards them, and a
-worktree with uncommitted tracked changes refuses to refresh. With `-s`, `grove add` prints
-the path of an existing worktree for the branch instead of erroring.
+`grove add --pr N` on a same-repo PR that already has a worktree refreshes it: a clean
+worktree is fast-forwarded, a branch with local commits errors unless `--reset` discards them,
+and a worktree with uncommitted tracked changes refuses to refresh. Fork PRs still error. With
+`-s`, `grove add` prints the path of an existing worktree for a branch instead of erroring.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ Add a worktree for a branch, pull request, or ref.
 
 **Flags:**
 
-- `-s, --switch` — Switch to worktree after creating
+- `-s, --switch` — Switch to the worktree; prints the path of an existing one instead of erroring
 - `--base <branch>` — Create new branch from this base instead of the default branch
-- `--no-fetch` — Skip fetching the base branch
+- `--no-fetch` — Skip fetching the base branch or the existing branch's upstream
 - `--name <name>` — Custom directory name
 - `-d, --detach` — Detached HEAD state
 - `--pr <number>` — Create worktree for a pull request
@@ -222,7 +222,7 @@ grove add --from dev feat/auth # Copy .env from dev worktree
 
 New branches start from the default branch on origin, fetched with a five-second timeout.
 If fetching fails, Grove warns with the base ref and commit age, then uses the existing
-origin ref, local default branch, or bare HEAD. Local branches and worktrees stay unchanged.
+origin ref, local default branch, or bare HEAD. Existing worktrees stay unchanged.
 An explicit `--base <branch>` fetches the branch from origin before resolving it, even
 when its remote-tracking ref is missing. It prefers `origin/<branch>`, falls back to the
 local branch, and errors if neither exists. `--base origin/<branch>` requires the origin
@@ -230,6 +230,14 @@ ref. `--base HEAD` selects the bare repository's HEAD without fetching.
 Use `--no-fetch` to skip fetching once, or
 `grove config set --global grove.fetchBase false` to disable it by default. Both leave the
 refs on disk untouched and pick from them in the same order.
+
+Adding an existing local branch fetches its upstream (`origin/<branch>` when none is
+configured) and fast-forwards the branch first when it is strictly behind; a branch that is
+ahead or diverged is checked out as is. `--no-fetch` skips that fetch too. Re-running
+`grove add --pr N` on a PR that already has a worktree refreshes it: a clean worktree is
+fast-forwarded, a branch with local commits errors unless `--reset` discards them, and a
+worktree with uncommitted tracked changes refuses to refresh. With `-s`, `grove add` prints
+the path of an existing worktree instead of erroring.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ ahead or diverged is checked out as is. `--no-fetch` skips that fetch too. Re-ru
 `grove add --pr N` on a PR that already has a worktree refreshes it: a clean worktree is
 fast-forwarded, a branch with local commits errors unless `--reset` discards them, and a
 worktree with uncommitted tracked changes refuses to refresh. With `-s`, `grove add` prints
-the path of an existing worktree instead of erroring.
+the path of an existing worktree for the branch instead of erroring.
 
 </details>
 

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -296,22 +296,29 @@ func fastForwardIfBehind(bareDir, branch string, fetch bool) {
 		logger.Warning("Failed to resolve upstream for %s: %v", branch, err)
 		return
 	}
-	if remoteRef == "" {
+	hasUpstream := remoteRef != ""
+	if !hasUpstream {
 		remoteRef, remote, remoteBranch = "origin/"+branch, "origin", branch
-		exists, err := git.RemoteBranchExists(bareDir, remote, branch)
-		if err != nil {
-			logger.Warning("Failed to check %s: %v", remoteRef, err)
-			return
-		}
-		if !exists {
-			return
-		}
 	}
 
 	if fetch {
 		if err := git.FetchBranch(bareDir, remote, remoteBranch); err != nil {
-			logger.Warning("Failed to fetch %s: %v", remoteRef, err)
+			// A branch that exists nowhere on the remote has nothing to fetch; only a known ref warns.
+			if known, _ := git.RemoteBranchExists(bareDir, remote, remoteBranch); known || hasUpstream {
+				logger.Warning("Failed to fetch %s: %v", remoteRef, err)
+			} else {
+				logger.Debug("Failed to fetch %s: %v", remoteRef, err)
+				return
+			}
 		}
+	}
+	exists, err := git.RemoteBranchExists(bareDir, remote, remoteBranch)
+	if err != nil {
+		logger.Warning("Failed to check %s: %v", remoteRef, err)
+		return
+	}
+	if !exists {
+		return
 	}
 	ahead, behind, err := git.CompareBranchRefs(bareDir, branch, remoteRef)
 	if err != nil {

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -56,7 +56,7 @@ Examples:
 	cmd.Flags().StringVar(&name, "name", "", "Custom directory name for the worktree")
 	cmd.Flags().BoolVarP(&detach, "detach", "d", false, "Create worktree in detached HEAD state")
 	cmd.Flags().IntVar(&prNumber, "pr", 0, "Pull request number to checkout")
-	cmd.Flags().BoolVar(&reset, "reset", false, "Reset diverged PR branch to match remote (discards local commits)")
+	cmd.Flags().BoolVar(&reset, "reset", false, "Reset diverged PR branch to match remote (discards local commits and untracked files the remote now tracks)")
 	cmd.Flags().StringVar(&from, "from", "", "Source worktree for file preservation (name or branch)")
 	cmd.Flags().BoolVar(&noFetch, "no-fetch", false, "Skip fetching the base branch or an existing branch's upstream")
 	cmd.Flags().BoolP("help", "h", false, "Help for add")

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -57,7 +57,7 @@ Examples:
 	cmd.Flags().IntVar(&prNumber, "pr", 0, "Pull request number to checkout")
 	cmd.Flags().BoolVar(&reset, "reset", false, "Reset diverged PR branch to match remote (discards local commits)")
 	cmd.Flags().StringVar(&from, "from", "", "Source worktree for file preservation (name or branch)")
-	cmd.Flags().BoolVar(&noFetch, "no-fetch", false, "Skip fetching the base branch from origin")
+	cmd.Flags().BoolVar(&noFetch, "no-fetch", false, "Skip fetching the base or existing local branch")
 	cmd.Flags().BoolP("help", "h", false, "Help for add")
 
 	_ = cmd.RegisterFlagCompletionFunc("base", completeBaseBranch)
@@ -264,6 +264,9 @@ func runAddFromBranch(branch string, switchTo bool, baseBranch, name, bareDir, w
 		if baseBranch != "" {
 			return fmt.Errorf("--base cannot be used with existing branch %q", branch)
 		}
+		if localExists {
+			fastForwardIfBehind(bareDir, branch, fetchBase)
+		}
 		if err := git.CreateWorktree(bareDir, worktreePath, git.CreateWorktreeOptions{Branch: branch}, true); err != nil {
 			return git.HintGitTooOld(fmt.Errorf("failed to create worktree: %w", err))
 		}
@@ -284,6 +287,42 @@ func runAddFromBranch(branch string, switchTo bool, baseBranch, name, bareDir, w
 
 	return finishWorktree(bareDir, sourceWorktree, worktreePath, branch, switchTo, releaseLock,
 		"Created worktree at %s", styles.RenderPath(worktreePath))
+}
+
+func fastForwardIfBehind(bareDir, branch string, fetch bool) {
+	cmd, cancel := git.GitCommand("git", "for-each-ref", "--format=%(upstream:short) %(upstream:remotename) %(upstream:remoteref)", "refs/heads/"+branch)
+	defer cancel()
+	cmd.Dir = bareDir
+	out, err := cmd.Output()
+	if err != nil {
+		logger.Warning("Failed to resolve upstream for %s: %v", branch, err)
+		return
+	}
+
+	remoteRef, remote, remoteBranch := "origin/"+branch, "origin", branch
+	if upstream := strings.Fields(string(out)); len(upstream) == 3 {
+		remoteRef, remote, remoteBranch = upstream[0], upstream[1], strings.TrimPrefix(upstream[2], "refs/heads/")
+	} else if exists, err := git.RemoteBranchExists(bareDir, remote, branch); err != nil || !exists {
+		return
+	}
+
+	if fetch {
+		if err := git.FetchBranch(bareDir, remote, remoteBranch); err != nil {
+			logger.Warning("Failed to fetch %s: %v", remoteRef, err)
+		}
+	}
+	ahead, behind, err := git.CompareBranchRefs(bareDir, branch, remoteRef)
+	if err != nil {
+		logger.Warning("Failed to compare %s with %s: %v", branch, remoteRef, err)
+		return
+	}
+	if ahead == 0 && behind > 0 {
+		if err := git.UpdateBranchRef(bareDir, branch, remoteRef); err != nil {
+			logger.Warning("Failed to fast-forward %s: %v", branch, err)
+			return
+		}
+		logger.Info("Fast-forwarded %s to %s (%d commits)", branch, remoteRef, behind)
+	}
 }
 
 func runAddDetached(ref string, switchTo bool, name, bareDir, workspaceRoot, sourceWorktree string, releaseLock func()) error {

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -58,7 +58,7 @@ Examples:
 	cmd.Flags().IntVar(&prNumber, "pr", 0, "Pull request number to checkout")
 	cmd.Flags().BoolVar(&reset, "reset", false, "Reset diverged PR branch to match remote (discards local commits)")
 	cmd.Flags().StringVar(&from, "from", "", "Source worktree for file preservation (name or branch)")
-	cmd.Flags().BoolVar(&noFetch, "no-fetch", false, "Skip fetching the base or existing local branch")
+	cmd.Flags().BoolVar(&noFetch, "no-fetch", false, "Skip fetching the base branch or an existing branch's upstream")
 	cmd.Flags().BoolP("help", "h", false, "Help for add")
 
 	_ = cmd.RegisterFlagCompletionFunc("base", completeBaseBranch)
@@ -438,17 +438,19 @@ func refreshExistingPRWorktree(bareDir, worktreePath, branch string, reset, swit
 	if ahead > 0 && !reset {
 		return fmt.Errorf("local branch %q has %d commit(s) not on remote (PR may have been rebased); use --reset to discard local commits and sync with remote", branch, ahead)
 	}
-	if ahead > 0 || behind > 0 {
-		// Move through the worktree so its index and files follow the branch.
+	// Move through the worktree so its index and files follow the branch.
+	switch {
+	case ahead > 0:
 		if err := git.ResetWorktreeHard(worktreePath, fetchedHash); err != nil {
 			return fmt.Errorf("failed to reset worktree: %w", err)
 		}
-		if ahead > 0 {
-			logger.Info("Reset %s to match remote (discarded %d local commits)", branch, ahead)
-		} else {
-			logger.Info("Fast-forwarded %s (%d commits)", branch, behind)
+		logger.Info("Reset %s to match remote (discarded %d local commits)", branch, ahead)
+	case behind > 0:
+		if err := git.FastForwardWorktree(worktreePath, fetchedHash); err != nil {
+			return fmt.Errorf("failed to fast-forward worktree: %w", err)
 		}
-	} else {
+		logger.Info("Fast-forwarded %s (%d commits)", branch, behind)
+	default:
 		logger.Info("Already up to date: %s", branch)
 	}
 	if switchTo {

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -395,6 +396,9 @@ func runAddFromPR(prRef string, switchTo bool, name, bareDir, workspaceRoot, sou
 	}
 	for _, info := range infos {
 		if info.Branch == branch {
+			if !prInfo.IsFork {
+				return refreshExistingPRWorktree(bareDir, info.Path, branch, reset, switchTo)
+			}
 			if switchTo {
 				logger.Info("Switching to existing worktree")
 				fmt.Println(info.Path)
@@ -414,6 +418,47 @@ func runAddFromPR(prRef string, switchTo bool, name, bareDir, workspaceRoot, sou
 
 	return finishWorktree(bareDir, sourceWorktree, worktreePath, branch, switchTo, releaseLock,
 		"Created worktree for PR #%d at %s", ref.Number, styles.RenderPath(worktreePath))
+}
+
+func refreshExistingPRWorktree(bareDir, worktreePath, branch string, reset, switchTo bool) error {
+	if err := git.FetchBranch(bareDir, "origin", branch); err != nil {
+		return fmt.Errorf("failed to fetch branch: %w", err)
+	}
+	fetchedHash, err := git.RevParse(bareDir, "FETCH_HEAD")
+	if err != nil {
+		return fmt.Errorf("failed to resolve fetched commit: %w", err)
+	}
+	_, hasTrackedChanges, err := git.CheckGitChanges(worktreePath)
+	if err != nil {
+		return fmt.Errorf("failed to check worktree changes: %w", err)
+	}
+	if hasTrackedChanges {
+		return errors.New("worktree has uncommitted changes; commit or stash before refreshing")
+	}
+	ahead, behind, err := git.CompareBranchRefs(bareDir, branch, fetchedHash)
+	if err != nil {
+		return fmt.Errorf("failed to compare branches: %w", err)
+	}
+	if ahead > 0 && !reset {
+		return fmt.Errorf("local branch %q has %d commit(s) not on remote (PR may have been rebased); use --reset to discard local commits and sync with remote", branch, ahead)
+	}
+	if ahead > 0 || behind > 0 {
+		// Move through the worktree so its index and files follow the branch.
+		if err := git.ResetWorktreeHard(worktreePath, fetchedHash); err != nil {
+			return fmt.Errorf("failed to reset worktree: %w", err)
+		}
+		if ahead > 0 {
+			logger.Info("Reset %s to match remote (discarded %d local commits)", branch, ahead)
+		} else {
+			logger.Info("Fast-forwarded %s (%d commits)", branch, behind)
+		}
+	} else {
+		logger.Info("Already up to date: %s", branch)
+	}
+	if switchTo {
+		fmt.Println(worktreePath)
+	}
+	return nil
 }
 
 func checkoutPR(bareDir, worktreePath string, ref *github.PRRef, prInfo *github.PRInfo, quiet, reset, existingWorkspace bool) error {

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -291,20 +291,21 @@ func runAddFromBranch(branch string, switchTo bool, baseBranch, name, bareDir, w
 }
 
 func fastForwardIfBehind(bareDir, branch string, fetch bool) {
-	cmd, cancel := git.GitCommand("git", "for-each-ref", "--format=%(upstream:short) %(upstream:remotename) %(upstream:remoteref)", "refs/heads/"+branch)
-	defer cancel()
-	cmd.Dir = bareDir
-	out, err := cmd.Output()
+	remoteRef, remote, remoteBranch, err := git.BranchUpstream(bareDir, branch)
 	if err != nil {
 		logger.Warning("Failed to resolve upstream for %s: %v", branch, err)
 		return
 	}
-
-	remoteRef, remote, remoteBranch := "origin/"+branch, "origin", branch
-	if upstream := strings.Fields(string(out)); len(upstream) == 3 {
-		remoteRef, remote, remoteBranch = upstream[0], upstream[1], strings.TrimPrefix(upstream[2], "refs/heads/")
-	} else if exists, err := git.RemoteBranchExists(bareDir, remote, branch); err != nil || !exists {
-		return
+	if remoteRef == "" {
+		remoteRef, remote, remoteBranch = "origin/"+branch, "origin", branch
+		exists, err := git.RemoteBranchExists(bareDir, remote, branch)
+		if err != nil {
+			logger.Warning("Failed to check %s: %v", remoteRef, err)
+			return
+		}
+		if !exists {
+			return
+		}
 	}
 
 	if fetch {
@@ -398,11 +399,6 @@ func runAddFromPR(prRef string, switchTo bool, name, bareDir, workspaceRoot, sou
 		if info.Branch == branch {
 			if !prInfo.IsFork {
 				return refreshExistingPRWorktree(bareDir, info.Path, branch, reset, switchTo)
-			}
-			if switchTo {
-				logger.Info("Switching to existing worktree")
-				fmt.Println(info.Path)
-				return nil
 			}
 			return fmt.Errorf("worktree already exists for branch %q at %s\n\nHint: Use 'grove list' to see existing worktrees, or use --name to choose a different directory", branch, info.Path)
 		}

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -224,6 +224,11 @@ func runAddFromBranch(branch string, switchTo bool, baseBranch, name, bareDir, w
 	}
 	for _, info := range infos {
 		if info.Branch == branch {
+			if switchTo {
+				logger.Info("Switching to existing worktree")
+				fmt.Println(info.Path)
+				return nil
+			}
 			return fmt.Errorf("worktree already exists for branch %q at %s\n\nHint: Use 'grove list' to see existing worktrees, or use --name to choose a different directory", branch, info.Path)
 		}
 	}
@@ -351,6 +356,11 @@ func runAddFromPR(prRef string, switchTo bool, name, bareDir, workspaceRoot, sou
 	}
 	for _, info := range infos {
 		if info.Branch == branch {
+			if switchTo {
+				logger.Info("Switching to existing worktree")
+				fmt.Println(info.Path)
+				return nil
+			}
 			return fmt.Errorf("worktree already exists for branch %q at %s\n\nHint: Use 'grove list' to see existing worktrees, or use --name to choose a different directory", branch, info.Path)
 		}
 	}

--- a/cmd/grove/testdata/script/add_fast_forward_ahead.txt
+++ b/cmd/grove/testdata/script/add_fast_forward_ahead.txt
@@ -1,0 +1,16 @@
+# Keep local commits when the branch is ahead of origin.
+setup_workspace old
+exec git -C $WORK/testrepo checkout old
+exec git -C $WORK/testrepo commit --allow-empty -m local-update
+exec git -C ../.bare fetch origin old
+exec git -C ../.bare branch -f old origin/old
+exec git -C $WORK/testrepo reset --hard HEAD~1
+exec git -C ../.bare fetch origin
+exec git -C ../.bare rev-parse old
+cp stdout $WORK/expected
+
+exec grove add old
+! stderr 'Fast-forwarded'
+exists ../old
+exec git -C ../old rev-parse HEAD
+cmp stdout $WORK/expected

--- a/cmd/grove/testdata/script/add_fast_forward_behind.txt
+++ b/cmd/grove/testdata/script/add_fast_forward_behind.txt
@@ -1,0 +1,15 @@
+# Fetch before fast-forwarding a local branch with no configured upstream.
+setup_workspace old
+exec git -C ../.bare branch -f --no-track old origin/old
+exec git -C $WORK/testrepo checkout old
+exec git -C $WORK/testrepo commit --allow-empty -m remote-update
+exec git -C $WORK/testrepo rev-parse old
+cp stdout $WORK/expected
+
+exec grove add old
+stderr 'Fast-forwarded old to origin/old \(1 commits\)'
+exists ../old
+exec git -C ../old rev-parse HEAD
+cmp stdout $WORK/expected
+exec git -C ../.bare rev-parse origin/old
+cmp stdout $WORK/expected

--- a/cmd/grove/testdata/script/add_fast_forward_diverged.txt
+++ b/cmd/grove/testdata/script/add_fast_forward_diverged.txt
@@ -1,0 +1,18 @@
+# Keep the local tip when local and remote have different commits.
+setup_workspace old
+exec git -C $WORK/testrepo checkout old
+exec git -C $WORK/testrepo commit --allow-empty -m local-update
+exec git -C ../.bare fetch origin old
+exec git -C ../.bare branch -f old origin/old
+exec git -C ../.bare rev-parse old
+cp stdout $WORK/expected
+exec git -C $WORK/testrepo reset --hard HEAD~1
+exec git -C $WORK/testrepo commit --allow-empty -m remote-update
+
+exec grove add old
+! stderr 'Fast-forwarded'
+exists ../old
+exec git -C ../old rev-parse HEAD
+cmp stdout $WORK/expected
+exec git -C ../.bare rev-list --left-right --count old...origin/old
+stdout '^1\s+1$'

--- a/cmd/grove/testdata/script/add_fast_forward_fetch_failure.txt
+++ b/cmd/grove/testdata/script/add_fast_forward_fetch_failure.txt
@@ -1,0 +1,13 @@
+# Offline adds warn but still create a worktree at the local tip.
+setup_workspace old
+exec git -C ../.bare branch -f old origin/old
+exec git -C ../.bare rev-parse old
+cp stdout $WORK/expected
+exec git -C ../.bare remote set-url origin $WORK/nonexistent
+
+exec grove add old
+stderr 'Failed to fetch origin/old'
+! stderr 'Fast-forwarded'
+exists ../old
+exec git -C ../old rev-parse HEAD
+cmp stdout $WORK/expected

--- a/cmd/grove/testdata/script/add_fast_forward_no_fetch.txt
+++ b/cmd/grove/testdata/script/add_fast_forward_no_fetch.txt
@@ -1,0 +1,17 @@
+# --no-fetch uses the cached remote tip without contacting origin.
+setup_workspace old
+exec git -C ../.bare branch -f old origin/old
+exec git -C $WORK/testrepo checkout old
+exec git -C $WORK/testrepo commit --allow-empty -m cached-update
+exec git -C ../.bare fetch origin old
+exec git -C ../.bare rev-parse origin/old
+cp stdout $WORK/expected
+exec git -C $WORK/testrepo commit --allow-empty -m unfetched-update
+exec git -C ../.bare remote set-url origin $WORK/nonexistent
+
+exec grove add --no-fetch old
+stderr 'Fast-forwarded old to origin/old \(1 commits\)'
+! stderr 'Failed to fetch'
+exists ../old
+exec git -C ../old rev-parse HEAD
+cmp stdout $WORK/expected

--- a/cmd/grove/testdata/script/add_fast_forward_uncached_remote.txt
+++ b/cmd/grove/testdata/script/add_fast_forward_uncached_remote.txt
@@ -1,0 +1,19 @@
+# A remote branch that was never fetched still fast-forwards the local branch.
+setup_workspace old
+exec git -C ../.bare branch -f --no-track old origin/old
+exec git -C ../.bare update-ref -d refs/remotes/origin/old
+exec git -C $WORK/testrepo checkout old
+exec git -C $WORK/testrepo commit --allow-empty -m remote-update
+exec git -C $WORK/testrepo rev-parse old
+cp stdout $WORK/expected
+
+exec grove add old
+stderr 'Fast-forwarded old to origin/old \(1 commits\)'
+exec git -C ../old rev-parse HEAD
+cmp stdout $WORK/expected
+
+# A branch that exists nowhere on the remote adds quietly.
+exec git -C ../.bare branch local-only
+exec grove add local-only
+! stderr 'Failed to fetch'
+exists ../local-only

--- a/cmd/grove/testdata/script/add_fast_forward_upstream.txt
+++ b/cmd/grove/testdata/script/add_fast_forward_upstream.txt
@@ -1,0 +1,15 @@
+# A configured upstream takes priority over origin/<local-branch>.
+setup_workspace old topic/remote
+exec git -C ../.bare remote add upstream $WORK/testrepo
+exec git -C ../.bare fetch upstream
+exec git -C ../.bare branch -f old upstream/topic/remote
+exec git -C $WORK/testrepo checkout topic/remote
+exec git -C $WORK/testrepo commit --allow-empty -m upstream-update
+exec git -C $WORK/testrepo rev-parse HEAD
+cp stdout $WORK/expected
+
+exec grove add old
+stderr 'Fast-forwarded old to upstream/topic/remote \(1 commits\)'
+exists ../old
+exec git -C ../old rev-parse HEAD
+cmp stdout $WORK/expected

--- a/cmd/grove/testdata/script/add_pr_fake_gh.txt
+++ b/cmd/grove/testdata/script/add_pr_fake_gh.txt
@@ -34,13 +34,12 @@ stderr 'requires workspace context'
 env FAKE_GH_PR_VIEW=$WORK/same-repo-pr.json
 exec grove add https://github.com/acme/widgets/pull/18
 exists ../pr-18
-! exec grove add https://github.com/acme/widgets/pull/18
-stderr 'worktree already exists for branch "feature-pr"'
+exec grove add https://github.com/acme/widgets/pull/18
+stderr 'Already up to date'
 
-exec git -C $WORK/workspace/.bare remote set-url origin https://github.com/acme/widgets
-exec grove add -s --pr 18 --name unused
+exec grove add -s https://github.com/acme/widgets/pull/18 --name unused
 stdout '^'$WORK'/workspace/pr-18$'
-stderr 'Switching to existing worktree'
+stderr 'Already up to date'
 ! exists ../unused
 exists ../pr-18/.git
 

--- a/cmd/grove/testdata/script/add_pr_fake_gh.txt
+++ b/cmd/grove/testdata/script/add_pr_fake_gh.txt
@@ -37,6 +37,13 @@ exists ../pr-18
 ! exec grove add https://github.com/acme/widgets/pull/18
 stderr 'worktree already exists for branch "feature-pr"'
 
+exec git -C $WORK/workspace/.bare remote set-url origin https://github.com/acme/widgets
+exec grove add -s --pr 18 --name unused
+stdout '^'$WORK'/workspace/pr-18$'
+stderr 'Switching to existing worktree'
+! exists ../unused
+exists ../pr-18/.git
+
 # A fork PR asks gh for the fork URL before fetching its branch.
 mkdir $WORK/fork
 exec git -C $WORK/fork init
@@ -83,6 +90,8 @@ fork content
 ["auth","status"]
 ["pr","view","99999","--repo","acme/widgets","--json","headRefName,headRepository,headRepositoryOwner"]
 ["auth","status"]
+["auth","status"]
+["pr","view","18","--repo","acme/widgets","--json","headRefName,headRepository,headRepositoryOwner"]
 ["auth","status"]
 ["pr","view","18","--repo","acme/widgets","--json","headRefName,headRepository,headRepositoryOwner"]
 ["auth","status"]

--- a/cmd/grove/testdata/script/add_pr_fake_gh.txt
+++ b/cmd/grove/testdata/script/add_pr_fake_gh.txt
@@ -38,7 +38,7 @@ exec grove add https://github.com/acme/widgets/pull/18
 stderr 'Already up to date'
 
 exec grove add -s https://github.com/acme/widgets/pull/18 --name unused
-stdout '^'$WORK'/workspace/pr-18$'
+stdout '[/\\\\]workspace[/\\\\]pr-18$'
 stderr 'Already up to date'
 ! exists ../unused
 exists ../pr-18/.git

--- a/cmd/grove/testdata/script/add_pr_refresh.txt
+++ b/cmd/grove/testdata/script/add_pr_refresh.txt
@@ -1,0 +1,74 @@
+# Same-repo PR refresh updates the checked-out branch, index, and files.
+setup_workspace feature-pr
+env FAKE_GH_LOG=$WORK/gh.log
+env FAKE_GH_PR_VIEW=$WORK/pr.json
+env PR=https://github.com/acme/widgets/pull/18
+exec grove add $PR
+
+exec git -C $WORK/testrepo checkout feature-pr
+cp $WORK/remote.txt $WORK/testrepo/README.md
+exec git -C $WORK/testrepo commit -am remote
+exec git -C $WORK/testrepo rev-parse HEAD
+cp stdout $WORK/remote-head
+cp $WORK/untracked.txt ../pr-18/untracked.txt
+exec grove add $PR
+stderr 'Fast-forwarded feature-pr \(1 commits\)'
+! stdout .
+exec git -C ../pr-18 rev-parse HEAD
+cmp stdout $WORK/remote-head
+cmp ../pr-18/README.md $WORK/remote.txt
+cmp ../pr-18/untracked.txt $WORK/untracked.txt
+exec git -C ../pr-18 diff HEAD --exit-code
+
+# Re-running with -s prints the existing path, not the requested name.
+exec grove add -s $PR --name unused
+stdout '^'$WORK'/workspace/pr-18$'
+stderr 'Already up to date'
+! exists ../unused
+
+# Local commits require explicit reset, including when histories diverge.
+cp $WORK/local.txt ../pr-18/README.md
+exec git -C ../pr-18 commit -am local
+! exec grove add $PR
+stderr 'use --reset'
+cmp ../pr-18/README.md $WORK/local.txt
+exec git -C $WORK/testrepo commit --allow-empty -m divergence
+exec git -C $WORK/testrepo rev-parse HEAD
+cp stdout $WORK/remote-head
+! exec grove add $PR
+stderr 'use --reset'
+exec grove add $PR --reset
+exec git -C ../pr-18 rev-parse HEAD
+cmp stdout $WORK/remote-head
+cmp ../pr-18/README.md $WORK/remote.txt
+cmp ../pr-18/untracked.txt $WORK/untracked.txt
+exec git -C ../pr-18 diff HEAD --exit-code
+
+# Neither unstaged nor staged tracked changes may be discarded by reset.
+cp $WORK/local.txt ../pr-18/README.md
+! exec grove add $PR --reset
+stderr 'worktree has uncommitted changes; commit or stash before refreshing'
+cmp ../pr-18/README.md $WORK/local.txt
+exec git -C ../pr-18 add README.md
+! exec grove add $PR --reset
+stderr 'worktree has uncommitted changes; commit or stash before refreshing'
+cmp ../pr-18/README.md $WORK/local.txt
+exec git -C ../pr-18 rev-parse HEAD
+cmp stdout $WORK/remote-head
+exec git -C ../pr-18 reset --hard HEAD
+
+# Fetch failure is fatal, even with a cached remote ref.
+exec git -C $WORK/workspace/.bare remote set-url origin file://$WORK/missing
+! exec grove add $PR
+stderr 'failed to fetch branch'
+exec git -C ../pr-18 rev-parse HEAD
+cmp stdout $WORK/remote-head
+
+-- pr.json --
+{"headRefName":"feature-pr","headRepository":{"name":"widgets"},"headRepositoryOwner":{"login":"acme"}}
+-- remote.txt --
+remote content
+-- local.txt --
+local content
+-- untracked.txt --
+keep this file

--- a/cmd/grove/testdata/script/add_pr_refresh.txt
+++ b/cmd/grove/testdata/script/add_pr_refresh.txt
@@ -22,7 +22,7 @@ exec git -C ../pr-18 diff HEAD --exit-code
 
 # Re-running with -s prints the existing path, not the requested name.
 exec grove add -s $PR --name unused
-stdout '^'$WORK'/workspace/pr-18$'
+stdout '[/\\\\]workspace[/\\\\]pr-18$'
 stderr 'Already up to date'
 ! exists ../unused
 

--- a/cmd/grove/testdata/script/add_pr_refresh.txt
+++ b/cmd/grove/testdata/script/add_pr_refresh.txt
@@ -57,6 +57,24 @@ exec git -C ../pr-18 rev-parse HEAD
 cmp stdout $WORK/remote-head
 exec git -C ../pr-18 reset --hard HEAD
 
+# An untracked file that the remote now tracks is never overwritten by a fast-forward.
+cp $WORK/remote.txt $WORK/testrepo/new.txt
+exec git -C $WORK/testrepo add new.txt
+exec git -C $WORK/testrepo commit -m 'track new file'
+exec git -C $WORK/testrepo rev-parse HEAD
+cp stdout $WORK/new-head
+cp $WORK/local.txt ../pr-18/new.txt
+! exec grove add $PR
+stderr 'untracked working tree files would be overwritten'
+cmp ../pr-18/new.txt $WORK/local.txt
+exec git -C ../pr-18 rev-parse HEAD
+cmp stdout $WORK/remote-head
+rm ../pr-18/new.txt
+exec grove add $PR
+stderr 'Fast-forwarded feature-pr \(1 commits\)'
+cmp ../pr-18/new.txt $WORK/remote.txt
+cp $WORK/new-head $WORK/remote-head
+
 # Fetch failure is fatal, even with a cached remote ref.
 exec git -C $WORK/workspace/.bare remote set-url origin file://$WORK/missing
 ! exec grove add $PR

--- a/cmd/grove/testdata/script/add_switch_existing.txt
+++ b/cmd/grove/testdata/script/add_switch_existing.txt
@@ -10,14 +10,14 @@ cp $WORK/marker preserved/marker
 cp $WORK/marker linked/marker
 
 exec grove add -s feat
-stdout '^'$WORK'/workspace/feat$'
+stdout '[/\\\\]workspace[/\\\\]feat$'
 stderr 'Switching to existing worktree'
 ! exists ../feat/preserved
 ! exists ../feat/linked
 ! exists ../.grove-worktree.lock
 
 exec grove add --switch --name unused feat
-stdout '^'$WORK'/workspace/feat$'
+stdout '[/\\\\]workspace[/\\\\]feat$'
 stderr 'Switching to existing worktree'
 ! exists ../unused
 exec git worktree list --porcelain

--- a/cmd/grove/testdata/script/add_switch_existing.txt
+++ b/cmd/grove/testdata/script/add_switch_existing.txt
@@ -1,0 +1,39 @@
+setup_workspace feat
+exec grove add feat
+exists ../feat/.git
+exec git worktree list --porcelain
+cp stdout $WORK/worktrees-before
+
+cp $WORK/config.toml .grove.toml
+mkdir preserved linked
+cp $WORK/marker preserved/marker
+cp $WORK/marker linked/marker
+
+exec grove add -s feat
+stdout '^'$WORK'/workspace/feat$'
+stderr 'Switching to existing worktree'
+! exists ../feat/preserved
+! exists ../feat/linked
+! exists ../.grove-worktree.lock
+
+exec grove add --switch --name unused feat
+stdout '^'$WORK'/workspace/feat$'
+stderr 'Switching to existing worktree'
+! exists ../unused
+exec git worktree list --porcelain
+cmp stdout $WORK/worktrees-before
+
+mkdir ../occupied
+! exec grove add -s --name occupied another
+stderr 'directory already exists:'
+
+-- config.toml --
+[preserve]
+directories = ["preserved"]
+[link]
+patterns = ["linked"]
+[hooks]
+add = ["exit 1"]
+
+-- marker --
+unchanged

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -647,7 +647,7 @@ func SetHeadToDefaultBranch(bareDir string) error {
 
 // BranchUpstream returns the configured upstream of a local branch as the
 // short ref (origin/main), the remote name, and the remote branch name.
-// All three are empty when the branch has no upstream.
+// All three are empty when the branch has no upstream or does not exist.
 func BranchUpstream(repoPath, branch string) (remoteRef, remote, remoteBranch string, err error) {
 	if repoPath == "" || branch == "" {
 		return "", "", "", errors.New("repository path and branch name cannot be empty")

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -653,8 +653,11 @@ func BranchUpstream(repoPath, branch string) (remoteRef, remote, remoteBranch st
 		return "", "", "", errors.New("repository path and branch name cannot be empty")
 	}
 
-	logger.Debug("Executing: git for-each-ref refs/heads/%s in %s", branch, repoPath)
-	cmd, cancel := GitCommand("git", "for-each-ref", "--format=%(upstream:short) %(upstream:remotename) %(upstream:remoteref)", "refs/heads/"+branch) // nolint:gosec
+	// for-each-ref matches by path prefix, so refs/heads/feature also lists
+	// refs/heads/feature/sub; the refname field lets us keep the exact match only.
+	refName := "refs/heads/" + branch
+	logger.Debug("Executing: git for-each-ref %s in %s", refName, repoPath)
+	cmd, cancel := GitCommand("git", "for-each-ref", "--format=%(refname) %(upstream:short) %(upstream:remotename) %(upstream:remoteref)", refName) // nolint:gosec
 	defer cancel()
 	cmd.Dir = repoPath
 
@@ -662,9 +665,11 @@ func BranchUpstream(repoPath, branch string) (remoteRef, remote, remoteBranch st
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to resolve upstream for %q: %w", branch, err)
 	}
-	fields := strings.Fields(output)
-	if len(fields) != 3 {
-		return "", "", "", nil
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 4 && fields[0] == refName {
+			return fields[1], fields[2], strings.TrimPrefix(fields[3], "refs/heads/"), nil
+		}
 	}
-	return fields[0], fields[1], strings.TrimPrefix(fields[2], "refs/heads/"), nil
+	return "", "", "", nil
 }

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -644,3 +644,27 @@ func SetHeadToDefaultBranch(bareDir string) error {
 	}
 	return nil
 }
+
+// BranchUpstream returns the configured upstream of a local branch as the
+// short ref (origin/main), the remote name, and the remote branch name.
+// All three are empty when the branch has no upstream.
+func BranchUpstream(repoPath, branch string) (remoteRef, remote, remoteBranch string, err error) {
+	if repoPath == "" || branch == "" {
+		return "", "", "", errors.New("repository path and branch name cannot be empty")
+	}
+
+	logger.Debug("Executing: git for-each-ref refs/heads/%s in %s", branch, repoPath)
+	cmd, cancel := GitCommand("git", "for-each-ref", "--format=%(upstream:short) %(upstream:remotename) %(upstream:remoteref)", "refs/heads/"+branch) // nolint:gosec
+	defer cancel()
+	cmd.Dir = repoPath
+
+	output, err := executeWithOutput(cmd)
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to resolve upstream for %q: %w", branch, err)
+	}
+	fields := strings.Fields(output)
+	if len(fields) != 3 {
+		return "", "", "", nil
+	}
+	return fields[0], fields[1], strings.TrimPrefix(fields[2], "refs/heads/"), nil
+}

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -1354,3 +1354,52 @@ func TestRestoreBareHeadIfDangling(t *testing.T) {
 		}
 	})
 }
+
+func TestBranchUpstream(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty strings when the branch has no upstream", func(t *testing.T) {
+		t.Parallel()
+		repo := testgit.NewTestRepo(t)
+		repo.CreateBranch("feature")
+
+		remoteRef, remote, remoteBranch, err := BranchUpstream(repo.Path, "feature")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if remoteRef != "" || remote != "" || remoteBranch != "" {
+			t.Errorf("expected empty upstream, got %q %q %q", remoteRef, remote, remoteBranch)
+		}
+	})
+
+	t.Run("returns the configured upstream parts", func(t *testing.T) {
+		t.Parallel()
+		repo := testgit.NewTestRepo(t)
+		repo.CreateBranch("feature")
+		repo.AddRemote("upstream", repo.Path)
+		for _, args := range [][]string{
+			{"update-ref", "refs/remotes/upstream/renamed", "main"},
+			{"config", "branch.feature.remote", "upstream"},
+			{"config", "branch.feature.merge", "refs/heads/renamed"},
+		} {
+			if _, err := repo.Run(args...); err != nil {
+				t.Fatalf("git %v: %v", args, err)
+			}
+		}
+
+		remoteRef, remote, remoteBranch, err := BranchUpstream(repo.Path, "feature")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if remoteRef != "upstream/renamed" || remote != "upstream" || remoteBranch != "renamed" {
+			t.Errorf("unexpected upstream: %q %q %q", remoteRef, remote, remoteBranch)
+		}
+	})
+
+	t.Run("returns error for empty inputs", func(t *testing.T) {
+		t.Parallel()
+		if _, _, _, err := BranchUpstream("", "feature"); err == nil {
+			t.Error("expected error for empty repo path")
+		}
+	})
+}

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -1396,6 +1396,30 @@ func TestBranchUpstream(t *testing.T) {
 		}
 	})
 
+	t.Run("ignores a nested branch when the requested branch is missing", func(t *testing.T) {
+		t.Parallel()
+		repo := testgit.NewTestRepo(t)
+		repo.CreateBranch("feature/sub")
+		repo.AddRemote("origin", repo.Path)
+		for _, args := range [][]string{
+			{"update-ref", "refs/remotes/origin/feature/sub", "main"},
+			{"config", "branch.feature/sub.remote", "origin"},
+			{"config", "branch.feature/sub.merge", "refs/heads/feature/sub"},
+		} {
+			if _, err := repo.Run(args...); err != nil {
+				t.Fatalf("git %v: %v", args, err)
+			}
+		}
+
+		remoteRef, _, _, err := BranchUpstream(repo.Path, "feature")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if remoteRef != "" {
+			t.Errorf("expected no upstream for missing branch, got %q", remoteRef)
+		}
+	})
+
 	t.Run("returns error for empty inputs", func(t *testing.T) {
 		t.Parallel()
 		if _, _, _, err := BranchUpstream("", "feature"); err == nil {

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -1401,5 +1401,8 @@ func TestBranchUpstream(t *testing.T) {
 		if _, _, _, err := BranchUpstream("", "feature"); err == nil {
 			t.Error("expected error for empty repo path")
 		}
+		if _, _, _, err := BranchUpstream("repo", ""); err == nil {
+			t.Error("expected error for empty branch")
+		}
 	})
 }

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -54,6 +54,21 @@ type CreateWorktreeOptions struct {
 	NoCheckout bool
 }
 
+// FastForwardWorktree moves HEAD, the index, and tracked files forward to hash.
+// Untracked files that the target would overwrite make git refuse, so nothing local is lost.
+func FastForwardWorktree(worktreePath, hash string) error {
+	if worktreePath == "" || hash == "" {
+		return errors.New("worktree path and hash cannot be empty")
+	}
+
+	logger.Debug("Executing: git merge --ff-only %s in %s", hash, worktreePath)
+	cmd, cancel := GitCommand("git", "merge", "--ff-only", hash) // nolint:gosec
+	defer cancel()
+	cmd.Dir = worktreePath
+
+	return runGitCommand(cmd, true)
+}
+
 // ResetWorktreeHard resets HEAD, the index, and tracked files to hash.
 func ResetWorktreeHard(worktreePath, hash string) error {
 	if worktreePath == "" || hash == "" {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -54,6 +54,20 @@ type CreateWorktreeOptions struct {
 	NoCheckout bool
 }
 
+// ResetWorktreeHard resets HEAD, the index, and tracked files to hash.
+func ResetWorktreeHard(worktreePath, hash string) error {
+	if worktreePath == "" || hash == "" {
+		return errors.New("worktree path and hash cannot be empty")
+	}
+
+	logger.Debug("Executing: git reset --hard %s in %s", hash, worktreePath)
+	cmd, cancel := GitCommand("git", "reset", "--hard", hash, "--") // nolint:gosec
+	defer cancel()
+	cmd.Dir = worktreePath
+
+	return runGitCommand(cmd, true)
+}
+
 // CreateWorktree creates a worktree from a bare repository.
 func CreateWorktree(bareRepo, worktreePath string, opts CreateWorktreeOptions, quiet bool) error {
 	if bareRepo == "" {

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -59,6 +59,61 @@ func TestResetWorktreeHard(t *testing.T) {
 	}
 }
 
+func TestFastForwardWorktree(t *testing.T) {
+	repo := testgit.NewTestRepo(t)
+	base := strings.TrimSpace(repo.RunOutput("rev-parse", "HEAD"))
+	repo.WriteFile("new.txt", "tracked")
+	repo.Add("new.txt")
+	repo.Commit("track new file")
+	target := strings.TrimSpace(repo.RunOutput("rev-parse", "HEAD"))
+	if _, err := repo.Run("reset", "--hard", base); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+
+	t.Run("refuses to overwrite an untracked file", func(t *testing.T) {
+		repo.WriteFile("new.txt", "untracked")
+		if err := FastForwardWorktree(repo.Path, target); err == nil {
+			t.Fatal("expected error")
+		}
+		if got := strings.TrimSpace(repo.RunOutput("rev-parse", "HEAD")); got != base {
+			t.Fatalf("HEAD = %s, want %s", got, base)
+		}
+		content, err := os.ReadFile(filepath.Join(repo.Path, "new.txt"))
+		if err != nil || string(content) != "untracked" {
+			t.Fatalf("untracked file changed: %q, %v", content, err)
+		}
+		if err := os.Remove(filepath.Join(repo.Path, "new.txt")); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("fast-forwards HEAD, index, and files", func(t *testing.T) {
+		if err := FastForwardWorktree(repo.Path, target); err != nil {
+			t.Fatalf("FastForwardWorktree failed: %v", err)
+		}
+		if got := strings.TrimSpace(repo.RunOutput("rev-parse", "HEAD")); got != target {
+			t.Fatalf("HEAD = %s, want %s", got, target)
+		}
+		if got := repo.RunOutput("status", "--porcelain"); got != "" {
+			t.Fatalf("worktree is dirty: %s", got)
+		}
+	})
+
+	for _, tt := range []struct {
+		name, path, hash string
+	}{
+		{"empty path", "", target},
+		{"empty hash", repo.Path, ""},
+		{"invalid hash", repo.Path, "nonexistent"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := FastForwardWorktree(tt.path, tt.hash); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
 func TestCreateWorktree(t *testing.T) {
 	t.Run("fails with non-existent branch in empty repo", func(t *testing.T) {
 		tempDir := testutil.TempDir(t)

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -22,6 +22,43 @@ const (
 	errRefEmpty          = "ref cannot be empty"
 )
 
+func TestResetWorktreeHard(t *testing.T) {
+	repo := testgit.NewTestRepo(t)
+	target := strings.TrimSpace(repo.RunOutput("rev-parse", "HEAD"))
+	repo.WriteFile("reset.txt", "local commit")
+	repo.Add("reset.txt")
+	repo.Commit("local")
+	repo.WriteFile("reset.txt", "dirty")
+
+	if err := ResetWorktreeHard(repo.Path, target); err != nil {
+		t.Fatalf("ResetWorktreeHard failed: %v", err)
+	}
+	if got := strings.TrimSpace(repo.RunOutput("rev-parse", "HEAD")); got != target {
+		t.Fatalf("HEAD = %s, want %s", got, target)
+	}
+	if got := repo.RunOutput("status", "--porcelain"); got != "" {
+		t.Fatalf("worktree is dirty: %s", got)
+	}
+	if _, err := os.Stat(filepath.Join(repo.Path, "reset.txt")); !os.IsNotExist(err) {
+		t.Fatalf("reset.txt should be removed, got %v", err)
+	}
+
+	for _, tt := range []struct {
+		name, path, hash string
+	}{
+		{"empty path", "", target},
+		{"empty hash", repo.Path, ""},
+		{"invalid hash", repo.Path, "nonexistent"},
+		{"invalid path", filepath.Join(repo.Path, "missing"), target},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ResetWorktreeHard(tt.path, tt.hash); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
 func TestCreateWorktree(t *testing.T) {
 	t.Run("fails with non-existent branch in empty repo", func(t *testing.T) {
 		tempDir := testutil.TempDir(t)


### PR DESCRIPTION
**`grove add` is now re-runnable: an existing worktree is switched to or refreshed, and a stale local branch is fast-forwarded before its worktree is created.**

Running `grove add` twice for the same branch errored even with `-s`, re-running `add --pr N` could not refresh a PR worktree, and adding a local branch behind its remote produced a worktree at the stale commit. The fetch and divergence rules mirror the existing `--pr` checkout so a diverged branch is never moved without `--reset`, and a worktree with uncommitted tracked changes refuses to refresh.

#### Changes

- `add -s <branch>` and `add -s --pr N` print the path of an existing worktree for that branch and exit 0; without `-s` the existing error is unchanged, and `directory already exists` is unchanged.
- Re-running `add --pr N` on a same-repo PR fetches and fast-forwards a clean worktree, errors with the `use --reset` hint when local commits exist (`--reset` hard-resets through the worktree), and refuses when tracked changes are present; untracked files do not block.
- Adding an existing local branch fetches its configured upstream (else `origin/<branch>`), and moves the ref only when it is strictly behind; a fetch failure warns and continues, and `--no-fetch` skips it.
- New `git.BranchUpstream` and `git.ResetWorktreeHard` helpers; README documents the behavior; changelog entries added.

#### Decisions

- Fork PR worktrees are detached, so re-running `add --pr` on a fork still errors; the fork-PR epic ([ABU-281](https://linear.app/aburaya/issue/ABU-281)) will pick this up once fork PRs live on a real branch.
- The plain-branch fast-forward is gated by `fetchBase` (`--no-fetch` or `grove.fetchBase false`), matching how the base fetch is already disabled, rather than adding a second flag.
- `add --pr N` for a stale local branch that has no worktree still checks out the local tip, as before; only the existing-worktree re-run fast-forwards.

#### Test plan

- [x] Code review by Claude Opus 5 (cape:code-reviewer) on 8f39646, the fix delta 82a6bc6, and the review-feedback deltas bc773dc..2b0dfc7 and 5b83805..be620a2, findings addressed or dismissed
- [x] `make ci`
- [x] `go test ./cmd/grove/ -run 'TestScript/add_(switch_existing|fast_forward_.*|pr_refresh|pr_fake_gh|error_branch_has_worktree|error_directory_exists)$'`

#### Deferred verification

- R9 of [AI-81](https://linear.app/aburaya/issue/AI-81): backfilling `branch.<b>.grovePr` on `add --pr` re-run is not done, since nothing records `grovePr` yet; it lands with [ABU-270](https://linear.app/aburaya/issue/ABU-270).

---

Fixes ABU-279, AI-81