### PR TITLE
feat(exec): add --parallel with buffered per-worktree output

### DIFF
--- a/.changes/unreleased/added-AI-49.yaml
+++ b/.changes/unreleased/added-AI-49.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: '`grove exec -j/--parallel N` runs targets with bounded concurrency and buffered per-worktree output in completion order.'
+time: 2026-09-10T08:17:48+02:00

--- a/.changes/unreleased/added-AI-49.yaml
+++ b/.changes/unreleased/added-AI-49.yaml
@@ -1,3 +1,3 @@
 kind: Added
-body: '`grove exec -j/--parallel N` runs targets with bounded concurrency and buffered per-worktree output in completion order.'
+body: "`grove exec -j/--parallel N` runs targets with bounded concurrency, printing each worktree's buffered output as its command finishes."
 time: 2026-09-10T08:17:48+02:00

--- a/README.md
+++ b/README.md
@@ -445,12 +445,20 @@ Execute a command in worktrees.
 **Flags:**
 
 - `-a, --all` — Execute in all worktrees
-- `--fail-fast` — Stop on first failure
+- `-j, --parallel N`: Run at most N commands at once (default: 1)
+- `--fail-fast`: Stop starting commands after the first failure; running commands finish
+- `--json`: Write results as JSON to stdout and child output to stderr
+
+With `N > 1`, each worktree's header, stdout, and stderr appear together on stderr
+after its command exits, in completion order. Output is buffered in memory without
+a size cap. Parallel commands receive no stdin. With `N = 1` or no flag, output
+streams as before and commands inherit stdin.
 
 **Examples:**
 
 ```bash
 grove exec --all -- npm install
+grove exec --all -j 4 -- npm test
 grove exec main feat-auth -- git pull
 grove exec --all --fail-fast -- go build
 grove exec --all -- bash -c "npm install && npm test"

--- a/README.md
+++ b/README.md
@@ -450,12 +450,12 @@ Execute a command in worktrees.
 - `--json` — Write results as JSON to stdout and child output to stderr
 
 With `N > 1`, each worktree's header, stdout, and stderr appear together on stderr
-after its command exits, in completion order. Output is buffered in memory without
-a size cap. Parallel commands receive no stdin. `--json` always lists worktrees in
-target order, though with `--fail-fast` it can list more of them than a sequential
-run, since commands already running when the first failure lands still finish and
-still report. With `N = 1` or no flag, output
-streams as before and commands inherit stdin.
+as each command finishes. Output is buffered in memory without a size cap.
+Parallel commands receive no stdin. `--json` always lists worktrees in target
+order, though with `--fail-fast` it can list more of them than a sequential run,
+since commands already running when the first failure lands still finish and
+still report. With `N = 1` or no flag, output streams as before and commands
+inherit stdin.
 
 **Examples:**
 

--- a/README.md
+++ b/README.md
@@ -445,13 +445,14 @@ Execute a command in worktrees.
 **Flags:**
 
 - `-a, --all` — Execute in all worktrees
-- `-j, --parallel N`: Run at most N commands at once (default: 1)
-- `--fail-fast`: Stop starting commands after the first failure; running commands finish
-- `--json`: Write results as JSON to stdout and child output to stderr
+- `-j, --parallel N` — Run at most N commands at once (default: 1)
+- `--fail-fast` — Stop starting commands after the first failure; running commands finish
+- `--json` — Write results as JSON to stdout and child output to stderr
 
 With `N > 1`, each worktree's header, stdout, and stderr appear together on stderr
 after its command exits, in completion order. Output is buffered in memory without
-a size cap. Parallel commands receive no stdin. With `N = 1` or no flag, output
+a size cap. Parallel commands receive no stdin. `--json` always lists worktrees in
+target order, so the array matches a sequential run. With `N = 1` or no flag, output
 streams as before and commands inherit stdin.
 
 **Examples:**

--- a/README.md
+++ b/README.md
@@ -452,7 +452,9 @@ Execute a command in worktrees.
 With `N > 1`, each worktree's header, stdout, and stderr appear together on stderr
 after its command exits, in completion order. Output is buffered in memory without
 a size cap. Parallel commands receive no stdin. `--json` always lists worktrees in
-target order, so the array matches a sequential run. With `N = 1` or no flag, output
+target order, though with `--fail-fast` it can list more of them than a sequential
+run, since commands already running when the first failure lands still finish and
+still report. With `N = 1` or no flag, output
 streams as before and commands inherit stdin.
 
 **Examples:**

--- a/cmd/grove/commands/exec.go
+++ b/cmd/grove/commands/exec.go
@@ -62,7 +62,7 @@ func NewExecCmd() *cobra.Command {
 
 With --parallel N, run at most N commands at once. For N > 1, buffer each
 worktree's stdout and stderr in memory and print them with its header to stderr
-in completion order. Parallel commands receive no stdin. The default, N = 1,
+as each command finishes. Parallel commands receive no stdin. The default, N = 1,
 streams output and passes stdin through. With --fail-fast, stop starting commands
 after a failure and wait for commands already running.
 

--- a/cmd/grove/commands/exec.go
+++ b/cmd/grove/commands/exec.go
@@ -97,6 +97,7 @@ func runParallel(targets []execTarget, n int, run func(execTarget) execResult) [
 	semaphore := make(chan struct{}, n)
 	var waitGroup sync.WaitGroup
 	var mutex sync.Mutex
+	var outputMutex sync.Mutex
 	results := make([]execResult, len(targets))
 	stopped := false
 	started := 0
@@ -114,20 +115,28 @@ func runParallel(targets []execTarget, n int, run func(execTarget) execResult) [
 		started++
 		go func() {
 			defer waitGroup.Done()
-			defer func() { <-semaphore }()
 
 			result := run(target)
+			output := result.output
+			result.output = nil
 
+			// Publish state and free the slot before flushing, so a large block
+			// never stalls dispatch. The dispatcher takes the slot then the
+			// mutex, so it always sees this stopped value.
 			mutex.Lock()
-			defer mutex.Unlock()
-
 			stopped = stopped || result.stop
+			results[index] = result
+			mutex.Unlock()
+			<-semaphore
+
+			outputMutex.Lock()
+			defer outputMutex.Unlock()
+
 			if result.label != "" {
 				logger.Info("%s", result.label)
 			}
-			if result.output != nil {
-				_, _ = result.output.WriteTo(os.Stderr)
-				result.output = nil
+			if output != nil {
+				_, _ = output.WriteTo(os.Stderr)
 			}
 			if result.err != nil {
 				logger.Error("%s", result.err)
@@ -135,7 +144,6 @@ func runParallel(targets []execTarget, n int, run func(execTarget) execResult) [
 			if result.label != "" {
 				fmt.Fprintln(os.Stderr)
 			}
-			results[index] = result
 		}()
 		mutex.Unlock()
 	}

--- a/cmd/grove/commands/exec.go
+++ b/cmd/grove/commands/exec.go
@@ -98,8 +98,8 @@ func runParallel(targets []execTarget, n int, run func(execTarget) execResult) [
 	var waitGroup sync.WaitGroup
 	var mutex sync.Mutex
 	results := make([]execResult, len(targets))
-	completed := make([]bool, len(targets))
 	stopped := false
+	started := 0
 
 	for index, target := range targets {
 		semaphore <- struct{}{}
@@ -111,6 +111,7 @@ func runParallel(targets []execTarget, n int, run func(execTarget) execResult) [
 		}
 
 		waitGroup.Add(1)
+		started++
 		go func() {
 			defer waitGroup.Done()
 			defer func() { <-semaphore }()
@@ -135,7 +136,6 @@ func runParallel(targets []execTarget, n int, run func(execTarget) execResult) [
 				fmt.Fprintln(os.Stderr)
 			}
 			results[index] = result
-			completed[index] = true
 		}()
 		mutex.Unlock()
 	}
@@ -143,14 +143,7 @@ func runParallel(targets []execTarget, n int, run func(execTarget) execResult) [
 	waitGroup.Wait()
 
 	// Report in target order, so --json matches the sequential array regardless of who finished first.
-	ordered := make([]execResult, 0, len(targets))
-	for index, result := range results {
-		if completed[index] {
-			ordered = append(ordered, result)
-		}
-	}
-
-	return ordered
+	return results[:started]
 }
 
 func runExec(all, failFast, jsonOutput bool, parallel int, worktrees, command []string) error {

--- a/cmd/grove/commands/exec.go
+++ b/cmd/grove/commands/exec.go
@@ -97,10 +97,11 @@ func runParallel(targets []execTarget, n int, run func(execTarget) execResult) [
 	semaphore := make(chan struct{}, n)
 	var waitGroup sync.WaitGroup
 	var mutex sync.Mutex
-	results := make([]execResult, 0, len(targets))
+	results := make([]execResult, len(targets))
+	completed := make([]bool, len(targets))
 	stopped := false
 
-	for _, target := range targets {
+	for index, target := range targets {
 		semaphore <- struct{}{}
 		mutex.Lock()
 		if stopped {
@@ -133,14 +134,23 @@ func runParallel(targets []execTarget, n int, run func(execTarget) execResult) [
 			if result.label != "" {
 				fmt.Fprintln(os.Stderr)
 			}
-			results = append(results, result)
+			results[index] = result
+			completed[index] = true
 		}()
 		mutex.Unlock()
 	}
 
 	waitGroup.Wait()
 
-	return results
+	// Report in target order, so --json matches the sequential array regardless of who finished first.
+	ordered := make([]execResult, 0, len(targets))
+	for index, result := range results {
+		if completed[index] {
+			ordered = append(ordered, result)
+		}
+	}
+
+	return ordered
 }
 
 func runExec(all, failFast, jsonOutput bool, parallel int, worktrees, command []string) error {
@@ -184,7 +194,7 @@ func runExec(all, failFast, jsonOutput bool, parallel int, worktrees, command []
 		}
 	}
 
-	runOne := func(target execTarget, command []string, streaming bool) execResult {
+	runOne := func(target execTarget, streaming bool) execResult {
 		result := execResult{Name: target.name, Path: target.path}
 		cmd := exec.Command(command[0], command[1:]...) //nolint:gosec
 		cmd.Dir = target.path
@@ -227,11 +237,11 @@ func runExec(all, failFast, jsonOutput bool, parallel int, worktrees, command []
 	results := make([]execResult, 0, len(targets))
 	if parallel > 1 {
 		results = runParallel(targets, parallel, func(target execTarget) execResult {
-			return runOne(target, command, false)
+			return runOne(target, false)
 		})
 	} else {
 		for _, target := range targets {
-			result := runOne(target, command, true)
+			result := runOne(target, true)
 			results = append(results, result)
 			if result.stop {
 				break

--- a/cmd/grove/commands/exec.go
+++ b/cmd/grove/commands/exec.go
@@ -1,12 +1,14 @@
 package commands
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 
 	"github.com/spf13/cobra"
 	"github.com/sqve/grove/internal/formatter"
@@ -23,6 +25,11 @@ type execResult struct {
 	Name     string `json:"name"`
 	Path     string `json:"path"`
 	ExitCode int    `json:"exit_code"`
+
+	label  string
+	output *bytes.Buffer
+	err    error
+	stop   bool
 }
 
 // ExecError reports an exec command failure with its process exit code.
@@ -46,14 +53,22 @@ func NewExecCmd() *cobra.Command {
 	var all bool
 	var failFast bool
 	var jsonOutput bool
+	var parallel int
 
 	cmd := &cobra.Command{
 		Use:   "exec [--all | <worktree>...] -- <command>",
 		Short: "Execute a command in worktrees",
 		Long: `Run a command in one or more worktrees.
 
+With --parallel N, run at most N commands at once. For N > 1, buffer each
+worktree's stdout and stderr in memory and print them with its header to stderr
+in completion order. Parallel commands receive no stdin. The default, N = 1,
+streams output and passes stdin through. With --fail-fast, stop starting commands
+after a failure and wait for commands already running.
+
 Examples:
   grove exec --all -- npm install                        # All worktrees
+  grove exec --all -j 4 -- npm test                       # Four at a time
   grove exec main feature -- npm ci                      # Named worktrees
   grove exec --all --fail-fast -- go build               # Stop on first failure
   grove exec --all --json -- npm test                    # JSON results
@@ -65,19 +80,74 @@ Examples:
 			if dashPos < 0 {
 				return errors.New("missing \"--\" before the command")
 			}
-			return runExec(all, failFast, jsonOutput, args[:dashPos], args[dashPos:])
+			return runExec(all, failFast, jsonOutput, parallel, args[:dashPos], args[dashPos:])
 		},
 	}
 
 	cmd.Flags().BoolVarP(&all, "all", "a", false, "Execute in all worktrees")
-	cmd.Flags().BoolVar(&failFast, "fail-fast", false, "Stop on first failure")
+	cmd.Flags().IntVarP(&parallel, "parallel", "j", 1, "Maximum concurrent commands (buffer output when greater than 1)")
+	cmd.Flags().BoolVar(&failFast, "fail-fast", false, "Stop starting commands after first failure")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results as JSON")
 	cmd.Flags().BoolP("help", "h", false, "Help for exec")
 
 	return cmd
 }
 
-func runExec(all, failFast, jsonOutput bool, worktrees, command []string) error {
+func runParallel(targets []execTarget, n int, run func(execTarget) execResult) []execResult {
+	semaphore := make(chan struct{}, n)
+	var waitGroup sync.WaitGroup
+	var mutex sync.Mutex
+	results := make([]execResult, 0, len(targets))
+	stopped := false
+
+	for _, target := range targets {
+		semaphore <- struct{}{}
+		mutex.Lock()
+		if stopped {
+			mutex.Unlock()
+			<-semaphore
+			break
+		}
+
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			defer func() { <-semaphore }()
+
+			result := run(target)
+
+			mutex.Lock()
+			defer mutex.Unlock()
+
+			stopped = stopped || result.stop
+			if result.label != "" {
+				logger.Info("%s", result.label)
+			}
+			if result.output != nil {
+				_, _ = result.output.WriteTo(os.Stderr)
+				result.output = nil
+			}
+			if result.err != nil {
+				logger.Error("%s", result.err)
+			}
+			if result.label != "" {
+				fmt.Fprintln(os.Stderr)
+			}
+			results = append(results, result)
+		}()
+		mutex.Unlock()
+	}
+
+	waitGroup.Wait()
+
+	return results
+}
+
+func runExec(all, failFast, jsonOutput bool, parallel int, worktrees, command []string) error {
+	if parallel < 1 {
+		return errors.New("parallel must be at least 1")
+	}
+
 	// Validation: must have a command
 	if len(command) == 0 {
 		return errors.New("no command specified after --")
@@ -114,42 +184,71 @@ func runExec(all, failFast, jsonOutput bool, worktrees, command []string) error 
 		}
 	}
 
-	// Execute command in each worktree
-	var failed []string
-	results := make([]execResult, 0, len(targets))
-	succeeded := 0
-	for _, target := range targets {
-		if !jsonOutput {
-			logger.Info("%s", target.label)
-		}
-
+	runOne := func(target execTarget, command []string, streaming bool) execResult {
+		result := execResult{Name: target.name, Path: target.path}
 		cmd := exec.Command(command[0], command[1:]...) //nolint:gosec
 		cmd.Dir = target.path
-		cmd.Stdin = os.Stdin
-		if jsonOutput {
-			cmd.Stdout = os.Stderr
-		} else {
-			cmd.Stdout = os.Stdout
-		}
-		cmd.Stderr = os.Stderr
-
-		exitCode := 0
-		if err := cmd.Run(); err != nil {
-			exitCode = commandExitCode(err)
-			failed = append(failed, target.name)
-			if !isExitError(err) {
-				logger.Error("%s", err)
+		if streaming {
+			if !jsonOutput {
+				logger.Info("%s", target.label)
 			}
+			cmd.Stdin = os.Stdin
+			if jsonOutput {
+				cmd.Stdout = os.Stderr
+			} else {
+				cmd.Stdout = os.Stdout
+			}
+			cmd.Stderr = os.Stderr
+		} else {
+			result.output = &bytes.Buffer{}
+			// Sharing the writer makes os/exec copy both streams without concurrent writes.
+			cmd.Stdout = result.output
+			cmd.Stderr = result.output
+			if !jsonOutput {
+				result.label = target.label
+			}
+		}
+
+		if err := cmd.Run(); err != nil {
+			result.ExitCode = commandExitCode(err)
+			result.stop = failFast
+			if !isExitError(err) {
+				if streaming {
+					logger.Error("%s", err)
+				} else {
+					result.err = err
+				}
+			}
+		}
+
+		return result
+	}
+
+	results := make([]execResult, 0, len(targets))
+	if parallel > 1 {
+		results = runParallel(targets, parallel, func(target execTarget) execResult {
+			return runOne(target, command, false)
+		})
+	} else {
+		for _, target := range targets {
+			result := runOne(target, command, true)
+			results = append(results, result)
+			if result.stop {
+				break
+			}
+			if !jsonOutput {
+				fmt.Fprintln(os.Stderr) // Blank line between worktrees
+			}
+		}
+	}
+
+	var failed []string
+	succeeded := 0
+	for _, result := range results {
+		if result.ExitCode != 0 {
+			failed = append(failed, result.Name)
 		} else {
 			succeeded++
-		}
-		results = append(results, execResult{Name: target.name, Path: target.path, ExitCode: exitCode})
-
-		if failFast && exitCode != 0 {
-			break
-		}
-		if !jsonOutput {
-			fmt.Fprintln(os.Stderr) // Blank line between worktrees
 		}
 	}
 

--- a/cmd/grove/commands/exec_parallel_test.go
+++ b/cmd/grove/commands/exec_parallel_test.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRunParallel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns all results with at most four targets in flight", func(t *testing.T) {
+		t.Parallel()
+
+		var mutex sync.Mutex
+		inFlight, maximum := 0, 0
+		started := make(chan struct{}, 8)
+		release := make(chan struct{})
+		done := make(chan []execResult, 1)
+		go func() {
+			done <- runParallel(make([]execTarget, 8), 4, func(execTarget) execResult {
+				mutex.Lock()
+				inFlight++
+				maximum = max(maximum, inFlight)
+				mutex.Unlock()
+
+				started <- struct{}{}
+				<-release
+
+				mutex.Lock()
+				inFlight--
+				mutex.Unlock()
+
+				return execResult{}
+			})
+		}()
+
+		defer close(release)
+		for range 4 {
+			select {
+			case <-started:
+			case <-time.After(5 * time.Second):
+				t.Fatal("four targets did not start concurrently")
+			}
+		}
+		for range 8 {
+			release <- struct{}{}
+		}
+
+		results := <-done
+		if len(results) != 8 {
+			t.Fatalf("expected eight results, got %d", len(results))
+		}
+		if maximum != 4 {
+			t.Errorf("expected maximum concurrency four, got %d", maximum)
+		}
+	})
+}

--- a/cmd/grove/commands/exec_test.go
+++ b/cmd/grove/commands/exec_test.go
@@ -45,7 +45,7 @@ func TestRunExec_NotInWorkspace(t *testing.T) {
 	tmpDir := testutil.TempDir(t)
 	testutil.Chdir(t, tmpDir)
 
-	err := runExec(true, false, false, nil, []string{"echo", "hello"})
+	err := runExec(true, false, false, 1, nil, []string{"echo", "hello"})
 	if !errors.Is(err, workspace.ErrNotInWorkspace) {
 		t.Errorf("expected ErrNotInWorkspace, got: %v", err)
 	}
@@ -53,7 +53,7 @@ func TestRunExec_NotInWorkspace(t *testing.T) {
 
 func TestRunExec_NoTargets(t *testing.T) {
 	// No --all and no worktree args
-	err := runExec(false, false, false, nil, []string{"echo", "hello"})
+	err := runExec(false, false, false, 1, nil, []string{"echo", "hello"})
 	if err == nil {
 		t.Error("expected error for no targets")
 	}
@@ -64,7 +64,7 @@ func TestRunExec_NoTargets(t *testing.T) {
 
 func TestRunExec_NoCommand(t *testing.T) {
 	// No command after --
-	err := runExec(true, false, false, nil, nil)
+	err := runExec(true, false, false, 1, nil, nil)
 	if err == nil {
 		t.Error("expected error for no command")
 	}
@@ -75,7 +75,7 @@ func TestRunExec_NoCommand(t *testing.T) {
 
 func TestRunExec_AllWithWorktrees(t *testing.T) {
 	// Both --all and worktree args specified
-	err := runExec(true, false, false, []string{"main"}, []string{"echo", "hello"})
+	err := runExec(true, false, false, 1, []string{"main"}, []string{"echo", "hello"})
 	if err == nil {
 		t.Error("expected error when both --all and worktrees specified")
 	}
@@ -152,7 +152,7 @@ func TestRunExec_AllWorktrees(t *testing.T) {
 	testutil.Chdir(t, mainPath)
 
 	// Run command in all worktrees (creates a marker file)
-	err := runExec(true, false, false, nil, []string{"touch", "exec-marker.txt"})
+	err := runExec(true, false, false, 1, nil, []string{"touch", "exec-marker.txt"})
 	if err != nil {
 		t.Fatalf("runExec failed: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestRunExec_SpecificWorktrees(t *testing.T) {
 	testutil.Chdir(t, mainPath)
 
 	// Run command only in main and feature (not bugfix)
-	err := runExec(false, false, false, []string{"main", "feature"}, []string{"touch", "specific-marker.txt"})
+	err := runExec(false, false, false, 1, []string{"main", "feature"}, []string{"touch", "specific-marker.txt"})
 	if err != nil {
 		t.Fatalf("runExec failed: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestRunExec_InvalidWorktree(t *testing.T) {
 	testutil.Chdir(t, mainPath)
 
 	// Try to run in non-existent worktree
-	err := runExec(false, false, false, []string{"nonexistent"}, []string{"echo", "hello"})
+	err := runExec(false, false, false, 1, []string{"nonexistent"}, []string{"echo", "hello"})
 	if err == nil {
 		t.Error("expected error for non-existent worktree")
 	}
@@ -243,7 +243,7 @@ func TestRunExec_CommandFails_ContinuesByDefault(t *testing.T) {
 
 	// Run a command that creates a marker file then fails (exit 1).
 	// Both worktrees will fail, but execution should continue to all worktrees.
-	err := runExec(true, false, false, nil, []string{"sh", "-c", "touch marker.txt && exit 1"})
+	err := runExec(true, false, false, 1, nil, []string{"sh", "-c", "touch marker.txt && exit 1"})
 
 	// Should return error (all executions failed)
 	if err == nil {
@@ -277,7 +277,7 @@ func TestRunExec_SingleTargetExitCode(t *testing.T) {
 			if test.name == "signal" && runtime.GOOS == "windows" {
 				t.Skip("Windows has no signal exit status; sh reports 3840")
 			}
-			err := runExec(false, false, false, []string{"main"}, []string{"sh", "-c", test.command})
+			err := runExec(false, false, false, 1, []string{"main"}, []string{"sh", "-c", test.command})
 			exitError, ok := err.(interface{ ExitCode() int })
 			if !ok {
 				t.Fatalf("expected exit-code error, got %v", err)
@@ -308,7 +308,7 @@ func TestRunExec_FailFast(t *testing.T) {
 
 	// Run a command that creates a marker then fails, with --fail-fast.
 	// Worktrees are processed in alphabetical order by branch name.
-	err := runExec(true, true, false, nil, []string{"sh", "-c", "touch failfast-marker.txt && exit 1"})
+	err := runExec(true, true, false, 1, nil, []string{"sh", "-c", "touch failfast-marker.txt && exit 1"})
 
 	// Should return error
 	if err == nil {
@@ -341,7 +341,7 @@ func TestRunExec_FindsByDirectoryName(t *testing.T) {
 	testutil.Chdir(t, mainPath)
 
 	// Run command using directory name (not branch name)
-	err := runExec(false, false, false, []string{"feat-auth"}, []string{"touch", "found-by-dir.txt"})
+	err := runExec(false, false, false, 1, []string{"feat-auth"}, []string{"touch", "found-by-dir.txt"})
 	if err != nil {
 		t.Fatalf("runExec should find worktree by directory name: %v", err)
 	}
@@ -462,7 +462,7 @@ func TestRunExec_PartialFailure(t *testing.T) {
 		}
 	}
 
-	err := runExec(true, false, false, nil, []string{"test", "-f", "marker.txt"})
+	err := runExec(true, false, false, 1, nil, []string{"test", "-f", "marker.txt"})
 	if err == nil {
 		t.Fatal("expected error for partial failure")
 	}
@@ -488,7 +488,7 @@ func TestRunExec_DuplicateWorktrees(t *testing.T) {
 
 	// Run command with same worktree specified twice. The command appends to a file,
 	// so we can check it ran only once by verifying the file content.
-	err := runExec(false, false, false, []string{"feature", "feature"}, []string{"sh", "-c", "echo x >> dedup-marker.txt"})
+	err := runExec(false, false, false, 1, []string{"feature", "feature"}, []string{"sh", "-c", "echo x >> dedup-marker.txt"})
 	if err != nil {
 		t.Fatalf("runExec failed: %v", err)
 	}

--- a/cmd/grove/testdata/script/exec_parallel.txt
+++ b/cmd/grove/testdata/script/exec_parallel.txt
@@ -1,4 +1,4 @@
-# Buffered blocks include both streams and appear only after exit, in completion order.
+# Buffered blocks include both streams and appear only after exit, as each command finishes.
 # Skip on Windows: children coordinate completion order through Unix shell path expansion
 [windows] skip
 setup_workspace feature

--- a/cmd/grove/testdata/script/exec_parallel.txt
+++ b/cmd/grove/testdata/script/exec_parallel.txt
@@ -1,0 +1,45 @@
+# Buffered blocks include both streams and appear only after exit, in completion order.
+setup_workspace feature
+exec grove add feature
+
+exec grove --plain exec main feature -j 2 -- sh $WORK/output.sh
+cmp stderr $WORK/expected.txt
+! stdout .
+
+# Parallel children do not inherit caller stdin.
+stdin $WORK/input.txt
+exec grove exec main --parallel 2 -- cat
+! stdout .
+! stderr 'caller input'
+
+# Invalid limits fail before workspace or command validation.
+cd $WORK
+! exec grove exec -j 0 --
+stderr 'parallel must be at least 1'
+! exec grove exec --parallel=-2 --
+stderr 'parallel must be at least 1'
+
+-- output.sh --
+name=${PWD##*/}
+echo "$name-out-1"
+if [ "$name" = main ]; then
+  while [ ! -f ../feature/done ]; do sleep 0.01; done
+  sleep 0.2
+fi
+echo "$name-err" >&2
+echo "$name-out-2"
+touch done
+-- expected.txt --
+feature [feature]
+feature-out-1
+feature-err
+feature-out-2
+
+main [main]
+main-out-1
+main-err
+main-out-2
+
+Executed in 2 worktrees
+-- input.txt --
+caller input

--- a/cmd/grove/testdata/script/exec_parallel.txt
+++ b/cmd/grove/testdata/script/exec_parallel.txt
@@ -1,4 +1,6 @@
 # Buffered blocks include both streams and appear only after exit, in completion order.
+# Skip on Windows: children coordinate completion order through Unix shell path expansion
+[windows] skip
 setup_workspace feature
 exec grove add feature
 

--- a/cmd/grove/testdata/script/exec_parallel_fail_fast.txt
+++ b/cmd/grove/testdata/script/exec_parallel_fail_fast.txt
@@ -1,4 +1,6 @@
 # A failure stops dispatch, but the other running child finishes.
+# Skip on Windows: children branch on Unix shell path matching to pick who fails
+[windows] skip
 setup_workspace feature skipped
 exec grove add feature
 exec grove add skipped

--- a/cmd/grove/testdata/script/exec_parallel_fail_fast.txt
+++ b/cmd/grove/testdata/script/exec_parallel_fail_fast.txt
@@ -1,0 +1,29 @@
+# A failure stops dispatch, but the other running child finishes.
+setup_workspace feature skipped
+exec grove add feature
+exec grove add skipped
+
+! exec grove --plain exec main feature skipped -j 2 --fail-fast -- sh $WORK/fail.sh
+exists main-started
+exists ../feature/finished
+! exists ../skipped/started
+stderr 'Stopped early, 1 worktrees skipped'
+stderr '1 succeeded, 1 failed'
+
+# Without fail-fast all targets run despite failures.
+! exec grove exec main feature skipped -j 2 -- sh -c 'touch started; exit 3'
+exists ../skipped/started
+
+-- fail.sh --
+touch started
+case "$PWD" in
+  */main)
+    touch main-started
+    while [ ! -f ../feature/started ]; do sleep 0.01; done
+    exit 3
+    ;;
+  */feature)
+    sleep 0.2
+    touch finished
+    ;;
+esac

--- a/cmd/grove/testdata/script/exec_parallel_json.txt
+++ b/cmd/grove/testdata/script/exec_parallel_json.txt
@@ -1,0 +1,30 @@
+# JSON keeps the sequential schema and exit codes, without buffered output on stdout.
+setup_workspace feature
+exec grove add feature
+cp $WORK/exists.txt only-in-main.txt
+
+! exec grove exec main feature -j 2 --json -- sh -c 'echo child-output; echo child-error >&2; test -f only-in-main.txt'
+stdout '^\['
+stdout -count=2 '"name":'
+stdout '"name": "main"'
+stdout '"path": ".*workspace[/\\]+main"'
+stdout '"exit_code": 0'
+stdout '"name": "feature"'
+stdout '"path": ".*workspace[/\\]+feature"'
+stdout '"exit_code": 1'
+! stdout 'child|output|label|stop'
+stderr -count=2 '^child-output$'
+stderr -count=2 '^child-error$'
+! stderr 'Executed|executions failed|→ main|→ feature'
+
+exec sh -c 'grove exec main -j 2 --json -- sh -c "exit 3"; test $? -eq 3'
+stdout '"exit_code": 3'
+exec sh -c 'grove exec main feature -j 2 --json -- false; test $? -eq 1'
+stdout -count=2 '"exit_code": 1'
+
+! exec grove exec main feature -j 2 --json -- grove-no-such-command-xyz
+stdout -count=2 '"exit_code": 1'
+stderr -count=2 'executable file not found'
+
+-- exists.txt --
+exists

--- a/cmd/grove/testdata/script/exec_parallel_json.txt
+++ b/cmd/grove/testdata/script/exec_parallel_json.txt
@@ -13,6 +13,8 @@ stdout '"name": "feature"'
 stdout '"path": ".*workspace[/\\]+feature"'
 stdout '"exit_code": 1'
 ! stdout 'child|output|label|stop'
+# Target order, not completion order, so the array matches sequential exec.
+stdout '(?s)"name": "main".*"name": "feature"'
 stderr -count=2 '^child-output$'
 stderr -count=2 '^child-error$'
 ! stderr 'Executed|executions failed|→ main|→ feature'

--- a/cmd/grove/testdata/script/exec_sequential_streaming.txt
+++ b/cmd/grove/testdata/script/exec_sequential_streaming.txt
@@ -1,0 +1,31 @@
+# Default and -j 1 retain stdout, stderr, headers, and stdin while the child runs.
+setup_workspace
+
+exec sh $WORK/check.sh
+exec sh $WORK/check.sh -j 1
+
+-- check.sh --
+rm -f release output errors
+echo caller-input | grove --plain exec main "$@" -- sh "$WORK/child.sh" >output 2>errors &
+process=$!
+for attempt in $(seq 1 200); do
+  if grep -q '^ready$' output && grep -q '^main \[main\]$' errors && grep -q '^child-error$' errors; then
+    touch release
+    wait "$process"
+    exit $?
+  fi
+  sleep 0.01
+done
+kill "$process"
+wait "$process"
+exit 1
+-- child.sh --
+read -r input
+[ "$input" = caller-input ] || exit 2
+echo ready
+echo child-error >&2
+for attempt in $(seq 1 200); do
+  [ -f release ] && exit 0
+  sleep 0.01
+done
+exit 3

--- a/internal/testutil/git/git.go
+++ b/internal/testutil/git/git.go
@@ -11,6 +11,9 @@ import (
 	"github.com/sqve/grove/internal/testutil"
 )
 
+// defaultBranch is the branch test repositories are initialized on.
+const defaultBranch = "main"
+
 // gitConfig holds a git configuration key-value pair.
 type gitConfig struct {
 	key, value string
@@ -62,7 +65,7 @@ func NewTestRepo(t *testing.T, branchName ...string) *TestRepo {
 		t.Fatalf("Failed to create repo dir: %v", err)
 	}
 
-	branch := "main"
+	branch := defaultBranch
 	if len(branchName) > 0 && branchName[0] != "" {
 		branch = branchName[0]
 	}
@@ -267,7 +270,7 @@ func NewBareTestRepo(t *testing.T) *BareTestRepo {
 	dir := testutil.TempDir(t)
 	bareDir := filepath.Join(dir, "repo.git")
 
-	cmd := exec.Command("git", "init", "--bare", "-b", "main") // nolint:gosec
+	cmd := exec.Command("git", "init", "--bare", "-b", defaultBranch) // nolint:gosec
 	if err := os.MkdirAll(bareDir, fs.DirGit); err != nil {
 		t.Fatalf("Failed to create bare repo dir: %v", err)
 	}
@@ -303,7 +306,7 @@ func NewGroveWorkspace(t *testing.T, branches ...string) *GroveWorkspace {
 	t.Helper()
 
 	if len(branches) == 0 {
-		branches = []string{"main"}
+		branches = []string{defaultBranch}
 	}
 
 	dir := testutil.TempDir(t)


### PR DESCRIPTION
**`grove exec` can now run commands across worktrees concurrently without their output interleaving.**

The exec loop was strictly sequential and streamed each child's output straight to the terminal, so running a build or test suite across a workspace cost the sum of every worktree. Targets now go through a bounded worker pool, and in parallel mode each child's output is buffered and flushed as one contiguous block when that child exits. Sequential mode is untouched, so no existing invocation changes behavior.

#### Changes

- `-j, --parallel N` caps how many commands run at once; values below 1 are rejected before any workspace or command validation.
- In parallel mode each worktree's header, stdout, and stderr print together as one block on stderr as each command finishes.
- `--fail-fast` stops dispatching new commands after the first failure and lets running ones finish, reporting how many were skipped.
- `--json` keeps the sequential schema, per-target exit codes, and process exit code, and lists worktrees in target order; a fail-fast run can list more worktrees than a sequential one, since commands already running when the failure lands still finish and still report.
- Without the flag, or at `-j 1`, output still streams live and commands still inherit stdin.

#### Decisions

- Parallel children write to stderr rather than stdout, because a header and both streams can only be kept contiguous when they go to one stream; scripts that redirect worktree stdout should stay sequential, and the README and help text say so.
- Parallel children get no stdin, since a single terminal cannot be shared across concurrent commands; sequential mode still passes it through.
- Buffers have no size cap, matching the epic contract; a worktree producing unbounded output holds it in memory until its command exits.
- One unrelated commit extracts a `defaultBranch` constant in `internal/testutil/git`: the pinned CI linter's `goconst` rule already fails on `main`, and this PR cannot go green without it.

#### Test plan

- [x] Code review by Claude Opus 5 (cape:code-reviewer) on c87494f, findings addressed in 6ba049e
- [x] `make ci` passes (lint, coverage tests, integration tests, build)
- [x] `go test -race ./cmd/grove/...` passes
- [x] All 20 `TestScript/exec_*` script tests pass, including non-interleaving, fail-fast, JSON, and sequential streaming
- [x] `TestRunParallel` holds concurrency at exactly 4 with 8 targets

---

Fixes ABU-267, AI-46