### PR TITLE
feat(remove): guard unmerged branches and skip missing targets

### DIFF
--- a/.changes/unreleased/changed-AI-73.yaml
+++ b/.changes/unreleased/changed-AI-73.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Check merge state before remove --branch and add --ignore-missing to skip unknown worktrees.
+time: 2026-09-10T08:40:49.210075567+02:00

--- a/README.md
+++ b/README.md
@@ -336,12 +336,13 @@ grove status --verbose
 
 <br>
 
-Remove one or more worktrees.
+Remove one or more worktrees. With `--branch`, unmerged branches are rejected before removal unless `--force` is set.
 
 **Flags:**
 
 - `-f, --force` — Remove even if dirty or locked; with `--branch`, delete unmerged and unpushed commits
 - `--branch` — Also delete the branch
+- `--ignore-missing` — Skip unknown targets with a warning
 
 **Examples:**
 
@@ -350,6 +351,7 @@ grove remove feat-auth
 grove remove feat-auth --branch
 grove remove --force wip
 grove remove feat-auth bugfix-123 # Remove multiple
+grove remove --ignore-missing feat-auth bugfix-123 # Skip missing worktrees
 ```
 
 </details>

--- a/cmd/grove/commands/remove.go
+++ b/cmd/grove/commands/remove.go
@@ -143,19 +143,17 @@ func runRemove(targets []string, force, deleteBranch, ignoreMissing bool) error 
 		forceDelete := force
 		if deleteThisBranch && !force && defaultBranch != "" {
 			merged, mergeErr := git.IsBranchMerged(bareDir, info.Branch, defaultBranch)
-			if mergeErr != nil {
-				logger.Error("%s: failed to check merge status: %v", displayName, mergeErr)
-				failed = append(failed, dirName)
-				continue
-			}
-			if !merged {
+			switch {
+			case mergeErr != nil:
+				logger.Debug("Could not verify merge status for %s: %v", info.Branch, mergeErr)
+			case !merged:
 				logger.Error("%s: branch is not merged into %s; use --force to delete anyway", info.Branch, defaultBranch)
 				failed = append(failed, dirName)
 				continue
+			default:
+				// Git's safe delete does not recognize squash merges.
+				forceDelete = true
 			}
-
-			// Git's safe delete does not recognize squash merges.
-			forceDelete = true
 		}
 
 		// Count commits before removing the worktree so branch deletion can warn.

--- a/cmd/grove/commands/remove.go
+++ b/cmd/grove/commands/remove.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -17,6 +18,7 @@ import (
 func NewRemoveCmd() *cobra.Command {
 	var force bool
 	var deleteBranch bool
+	var ignoreMissing bool
 
 	cmd := &cobra.Command{
 		Use:   "remove <worktree>...",
@@ -24,6 +26,7 @@ func NewRemoveCmd() *cobra.Command {
 		Long: `Remove one or more worktrees, optionally deleting their branches.
 
 Accepts worktree names (directories) or branch names.
+With --branch, unmerged branches are rejected before removal unless --force is set.
 
 Examples:
   grove remove feat-auth            # Remove worktree
@@ -33,18 +36,19 @@ Examples:
 		Args:              cobra.ArbitraryArgs,
 		ValidArgsFunction: worktreeCompletion(0, false, notCurrentWorktree),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRemove(args, force, deleteBranch)
+			return runRemove(args, force, deleteBranch, ignoreMissing)
 		},
 	}
 
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Remove even if dirty or locked; with --branch, delete unmerged and unpushed commits")
 	cmd.Flags().BoolVar(&deleteBranch, "branch", false, "Also delete the branch")
+	cmd.Flags().BoolVar(&ignoreMissing, "ignore-missing", false, "Skip worktrees that are not found")
 	cmd.Flags().BoolP("help", "h", false, "Help for remove")
 
 	return cmd
 }
 
-func runRemove(targets []string, force, deleteBranch bool) error {
+func runRemove(targets []string, force, deleteBranch, ignoreMissing bool) error {
 	if len(targets) == 0 {
 		return fmt.Errorf("requires at least one worktree")
 	}
@@ -54,13 +58,33 @@ func runRemove(targets []string, force, deleteBranch bool) error {
 		return err
 	}
 
-	cleaned := make([]string, len(targets))
-	for i, target := range targets {
-		cleaned[i] = strings.TrimSpace(target)
+	cleaned := make([]string, 0, len(targets))
+	var missing []string
+	for _, target := range targets {
+		target = strings.TrimSpace(target)
+		if ignoreMissing && git.FindWorktree(infos, target) == nil {
+			if !slices.Contains(missing, target) {
+				missing = append(missing, target)
+			}
+			continue
+		}
+		cleaned = append(cleaned, target)
 	}
+
 	toRemove, err := resolveWorktrees(infos, cleaned)
 	if err != nil {
 		return err
+	}
+	for _, target := range missing {
+		logger.Warning("%s: not found (skipped)", target)
+	}
+
+	var defaultBranch string
+	if deleteBranch && !force {
+		defaultBranch, err = git.GetDefaultBranch(bareDir)
+		if err != nil {
+			logger.Debug("Skipping merge check: could not determine default branch: %v", err)
+		}
 	}
 
 	// Process each target, accumulate successes and failures
@@ -115,9 +139,27 @@ func runRemove(targets []string, force, deleteBranch bool) error {
 			}
 		}
 
+		deleteThisBranch := deleteBranch && !info.Detached
+		forceDelete := force
+		if deleteThisBranch && !force && defaultBranch != "" {
+			merged, mergeErr := git.IsBranchMerged(bareDir, info.Branch, defaultBranch)
+			if mergeErr != nil {
+				logger.Error("%s: failed to check merge status: %v", displayName, mergeErr)
+				failed = append(failed, dirName)
+				continue
+			}
+			if !merged {
+				logger.Error("%s: branch is not merged into %s; use --force to delete anyway", info.Branch, defaultBranch)
+				failed = append(failed, dirName)
+				continue
+			}
+
+			// Git's safe delete does not recognize squash merges.
+			forceDelete = true
+		}
+
 		// Count commits before removing the worktree so branch deletion can warn.
 		var aheadCount, unreachableCount int
-		deleteThisBranch := deleteBranch && !info.Detached
 		if deleteThisBranch {
 			if force {
 				unreachableCount, err = git.CountUnreachableCommits(bareDir, info.Branch)
@@ -155,7 +197,7 @@ func runRemove(targets []string, force, deleteBranch bool) error {
 				logger.Warning("%s: branch has %d unpushed commit(s)", info.Branch, aheadCount)
 			}
 
-			if err := git.DeleteBranch(bareDir, info.Branch, force); err != nil {
+			if err := git.DeleteBranch(bareDir, info.Branch, forceDelete); err != nil {
 				logger.Error("%s: worktree removed but failed to delete branch: %v", displayName, err)
 				failed = append(failed, dirName)
 				continue

--- a/cmd/grove/commands/remove.go
+++ b/cmd/grove/commands/remove.go
@@ -101,7 +101,7 @@ func runRemove(targets []string, force, deleteBranch, ignoreMissing bool) error 
 				continue
 			}
 
-			mergeChecks[info.Branch] = merged
+			mergeChecks[info.Path] = merged
 		}
 	}
 
@@ -159,7 +159,7 @@ func runRemove(targets []string, force, deleteBranch, ignoreMissing bool) error 
 
 		deleteThisBranch := deleteBranch && !info.Detached
 		forceDelete := force
-		merged, checked := mergeChecks[info.Branch]
+		merged, checked := mergeChecks[info.Path]
 		if checked {
 			if !merged {
 				logger.Error("%s: branch is not merged into %s; use --force to delete anyway", info.Branch, defaultBranch)

--- a/cmd/grove/commands/remove.go
+++ b/cmd/grove/commands/remove.go
@@ -87,6 +87,24 @@ func runRemove(targets []string, force, deleteBranch, ignoreMissing bool) error 
 		}
 	}
 
+	// Validate all targets before a removal can delete the default branch ref.
+	mergeChecks := make(map[string]bool)
+	if deleteBranch && !force && defaultBranch != "" {
+		for _, info := range toRemove {
+			if info.Detached {
+				continue
+			}
+
+			merged, mergeErr := git.IsBranchMerged(bareDir, info.Branch, defaultBranch)
+			if mergeErr != nil {
+				logger.Debug("Could not verify merge status for %s: %v", info.Branch, mergeErr)
+				continue
+			}
+
+			mergeChecks[info.Branch] = merged
+		}
+	}
+
 	// Process each target, accumulate successes and failures
 	type removedWorktree struct {
 		path          string
@@ -141,19 +159,16 @@ func runRemove(targets []string, force, deleteBranch, ignoreMissing bool) error 
 
 		deleteThisBranch := deleteBranch && !info.Detached
 		forceDelete := force
-		if deleteThisBranch && !force && defaultBranch != "" {
-			merged, mergeErr := git.IsBranchMerged(bareDir, info.Branch, defaultBranch)
-			switch {
-			case mergeErr != nil:
-				logger.Debug("Could not verify merge status for %s: %v", info.Branch, mergeErr)
-			case !merged:
+		merged, checked := mergeChecks[info.Branch]
+		if checked {
+			if !merged {
 				logger.Error("%s: branch is not merged into %s; use --force to delete anyway", info.Branch, defaultBranch)
 				failed = append(failed, dirName)
 				continue
-			default:
-				// Git's safe delete does not recognize squash merges.
-				forceDelete = true
 			}
+
+			// Git's safe delete does not recognize squash merges.
+			forceDelete = true
 		}
 
 		// Count commits before removing the worktree so branch deletion can warn.

--- a/cmd/grove/commands/remove_test.go
+++ b/cmd/grove/commands/remove_test.go
@@ -44,7 +44,7 @@ func TestRunRemove_NotInWorkspace(t *testing.T) {
 	tmpDir := testutil.TempDir(t)
 	testutil.Chdir(t, tmpDir)
 
-	err := runRemove([]string{"some-branch"}, false, false)
+	err := runRemove([]string{"some-branch"}, false, false, false)
 	if !errors.Is(err, workspace.ErrNotInWorkspace) {
 		t.Errorf("expected ErrNotInWorkspace, got %v", err)
 	}
@@ -74,7 +74,7 @@ func TestRunRemove_WorktreeNotFound(t *testing.T) {
 	// Change to workspace
 	testutil.Chdir(t, mainPath)
 
-	err := runRemove([]string{"nonexistent"}, false, false)
+	err := runRemove([]string{"nonexistent"}, false, false, false)
 	if err == nil {
 		t.Error("expected error for non-existent branch")
 	}
@@ -107,7 +107,7 @@ func TestRunRemove_CurrentWorktree(t *testing.T) {
 	// Change to workspace (the worktree we'll try to remove)
 	testutil.Chdir(t, mainPath)
 
-	err := runRemove([]string{"main"}, false, false)
+	err := runRemove([]string{"main"}, false, false, false)
 	if err == nil {
 		t.Error("expected error when removing current worktree")
 	}
@@ -143,7 +143,7 @@ func TestRunRemove_CurrentWorktreeHint(t *testing.T) {
 	defer logger.SetOutput(nil)
 	logger.Init(true, false)
 
-	err := runRemove([]string{"main"}, false, false)
+	err := runRemove([]string{"main"}, false, false, false)
 	if err == nil {
 		t.Error("expected error when removing current worktree")
 	}
@@ -192,7 +192,7 @@ func TestRunRemove_DirtyWorktree(t *testing.T) {
 	// Change to main worktree (not the one we're removing)
 	testutil.Chdir(t, mainPath)
 
-	err := runRemove([]string{"feature"}, false, false)
+	err := runRemove([]string{"feature"}, false, false, false)
 	if err == nil {
 		t.Error("expected error for dirty worktree")
 	}
@@ -241,7 +241,7 @@ func TestRunRemove_LockedWorktree(t *testing.T) {
 	// Change to main worktree
 	testutil.Chdir(t, mainPath)
 
-	err := runRemove([]string{"feature"}, false, false)
+	err := runRemove([]string{"feature"}, false, false, false)
 	if err == nil {
 		t.Error("expected error for locked worktree")
 	}
@@ -315,7 +315,7 @@ func TestRunRemove_Success(t *testing.T) {
 		t.Fatal("feature worktree should exist before deletion")
 	}
 
-	err := runRemove([]string{"feature"}, false, false)
+	err := runRemove([]string{"feature"}, false, false, false)
 	if err != nil {
 		t.Fatalf("runRemove failed: %v", err)
 	}
@@ -374,7 +374,7 @@ func TestRunRemove_ForceDirty(t *testing.T) {
 	testutil.Chdir(t, mainPath)
 
 	// Force remove dirty worktree
-	err := runRemove([]string{"feature"}, true, false)
+	err := runRemove([]string{"feature"}, true, false, false)
 	if err != nil {
 		t.Fatalf("runRemove with force failed: %v", err)
 	}
@@ -425,7 +425,7 @@ func TestRunRemove_ForceLocked(t *testing.T) {
 	testutil.Chdir(t, mainPath)
 
 	// Force remove locked worktree
-	err := runRemove([]string{"feature"}, true, false)
+	err := runRemove([]string{"feature"}, true, false, false)
 	if err != nil {
 		t.Fatalf("runRemove with force failed: %v", err)
 	}
@@ -496,7 +496,7 @@ func TestRunRemove_WithBranchFlag(t *testing.T) {
 	testutil.Chdir(t, mainPath)
 
 	// Remove with --branch flag
-	err := runRemove([]string{"feature"}, false, true)
+	err := runRemove([]string{"feature"}, false, true, false)
 	if err != nil {
 		t.Fatalf("runRemove with --branch failed: %v", err)
 	}
@@ -552,7 +552,7 @@ func TestRunRemove_MultipleWorktrees(t *testing.T) {
 	testutil.Chdir(t, mainPath)
 
 	// Remove multiple worktrees at once
-	err := runRemove([]string{"feature", "bugfix"}, false, false)
+	err := runRemove([]string{"feature", "bugfix"}, false, false, false)
 	if err != nil {
 		t.Fatalf("runRemove failed: %v", err)
 	}
@@ -612,7 +612,7 @@ func TestRunRemove_MultipleWithForce(t *testing.T) {
 	testutil.Chdir(t, mainPath)
 
 	// Force remove both dirty and locked worktrees
-	err := runRemove([]string{"feature", "bugfix"}, true, false)
+	err := runRemove([]string{"feature", "bugfix"}, true, false, false)
 	if err != nil {
 		t.Fatalf("runRemove with force failed: %v", err)
 	}
@@ -667,7 +667,7 @@ func TestRunRemove_MultipleWithOneDirty(t *testing.T) {
 	testutil.Chdir(t, mainPath)
 
 	// Remove both without force - bugfix should fail, feature should succeed
-	err := runRemove([]string{"feature", "bugfix"}, false, false)
+	err := runRemove([]string{"feature", "bugfix"}, false, false, false)
 	if err == nil {
 		t.Fatal("expected error for dirty worktree")
 	}
@@ -728,7 +728,7 @@ func TestRunRemove_MultipleWithOneLocked(t *testing.T) {
 	testutil.Chdir(t, mainPath)
 
 	// Remove both without force - bugfix should fail, feature should succeed
-	err := runRemove([]string{"feature", "bugfix"}, false, false)
+	err := runRemove([]string{"feature", "bugfix"}, false, false, false)
 	if err == nil {
 		t.Fatal("expected error for locked worktree")
 	}
@@ -776,7 +776,7 @@ func TestRunRemove_MultipleWithOneCurrent(t *testing.T) {
 	testutil.Chdir(t, featurePath)
 
 	// Try to remove both current (feature) and main
-	err := runRemove([]string{"feature", "main"}, false, false)
+	err := runRemove([]string{"feature", "main"}, false, false, false)
 	if err == nil {
 		t.Fatal("expected error for current worktree")
 	}
@@ -857,7 +857,7 @@ func TestRunRemove_MultipleWithDeleteBranch(t *testing.T) {
 	testutil.Chdir(t, mainPath)
 
 	// Remove with --branch flag
-	err := runRemove([]string{"feature", "bugfix"}, false, true)
+	err := runRemove([]string{"feature", "bugfix"}, false, true, false)
 	if err != nil {
 		t.Fatalf("runRemove failed: %v", err)
 	}
@@ -917,7 +917,7 @@ func TestRunRemove_DuplicateArgs(t *testing.T) {
 	testutil.Chdir(t, mainPath)
 
 	// Remove with duplicate args (same worktree specified twice)
-	err := runRemove([]string{"feature", "feature"}, false, false)
+	err := runRemove([]string{"feature", "feature"}, false, false, false)
 	if err != nil {
 		t.Fatalf("runRemove with duplicates failed: %v", err)
 	}
@@ -968,7 +968,7 @@ func TestRunRemove_ErrorShowsWorktreeLabel(t *testing.T) {
 	defer logger.SetOutput(nil)
 	logger.Init(true, false)
 
-	_ = runRemove([]string{"feat-auth"}, false, false)
+	_ = runRemove([]string{"feat-auth"}, false, false, false)
 
 	output := buf.String()
 	// Error should show directory name as primary identifier with branch in brackets
@@ -1152,7 +1152,7 @@ func TestRunRemove_CurrentWorktreeSubdirectory(t *testing.T) {
 	}
 	testutil.Chdir(t, subDir)
 
-	err := runRemove([]string{"feature"}, false, false)
+	err := runRemove([]string{"feature"}, false, false, false)
 	if err == nil {
 		t.Error("expected error when removing worktree from subdirectory within it")
 	}

--- a/cmd/grove/testdata/script/remove_branch_default_first.txt
+++ b/cmd/grove/testdata/script/remove_branch_default_first.txt
@@ -1,0 +1,23 @@
+# Test: removing the default branch cannot bypass later merge checks
+setup_workspace other observer
+exec grove add other
+exec grove add observer
+cd ../other
+cp $WORK/newfile.txt newfile.txt
+exec git add newfile.txt
+exec git commit -m 'unmerged commit'
+cd ../observer
+exec grove unlock main
+
+! exec grove remove --branch main other
+stderr 'failed: other'
+exists ../other/newfile.txt
+stderr 'other: branch is not merged into main; use --force to delete anyway'
+stderr 'Removed worktree.*main'
+stderr 'deleted branch main'
+exec git show-ref --verify refs/heads/other
+! exists ../main
+! exec git show-ref --verify refs/heads/main
+
+-- newfile.txt --
+new content

--- a/cmd/grove/testdata/script/remove_branch_remote_default.txt
+++ b/cmd/grove/testdata/script/remove_branch_remote_default.txt
@@ -1,0 +1,13 @@
+# Test: remote-only default branch falls back to Git's safe delete
+setup_workspace feature
+exec grove add feature
+exec git branch -m main trunk
+exec git --git-dir=../.bare symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+! exec git show-ref --verify refs/heads/main
+exec git show-ref --verify refs/remotes/origin/main
+
+exec grove --debug remove --branch feature
+stderr 'Removed worktree.*feature'
+stderr 'Executing: git branch -d feature'
+! exists ../feature
+! exec git show-ref --verify refs/heads/feature

--- a/cmd/grove/testdata/script/remove_branch_squash_merged.txt
+++ b/cmd/grove/testdata/script/remove_branch_squash_merged.txt
@@ -1,0 +1,21 @@
+# Test: delete squash-merged branches even when git branch -d would reject them
+setup_workspace feature-squashed
+
+exec grove add feature-squashed
+cd ../feature-squashed
+cp $WORK/feature.txt feature.txt
+exec git add feature.txt
+exec git commit -m 'feature commit'
+cd ../main
+exec git merge --squash feature-squashed
+exec git commit -m 'squashed feature'
+! exec git merge-base --is-ancestor feature-squashed main
+
+exec grove remove --branch feature-squashed
+stderr 'Removed worktree.*feature-squashed'
+stderr 'deleted branch feature-squashed'
+! exists ../feature-squashed
+! exec git show-ref --verify refs/heads/feature-squashed
+
+-- feature.txt --
+feature content

--- a/cmd/grove/testdata/script/remove_branch_unknown_default.txt
+++ b/cmd/grove/testdata/script/remove_branch_unknown_default.txt
@@ -1,0 +1,14 @@
+# Test: unknown default branch keeps Git's existing safe-delete behavior
+setup_workspace feature
+exec grove add feature
+exec git branch -m main trunk
+exec git remote remove origin
+exec git --git-dir=../.bare symbolic-ref HEAD refs/heads/unknown
+
+! exec grove --debug remove --branch feature
+stderr 'Skipping merge check: could not determine default branch'
+stderr 'Removed worktree.*feature'
+stderr 'Executing: git branch -d feature'
+stderr 'worktree removed but failed to delete branch'
+! exists ../feature
+exec git show-ref --verify refs/heads/feature

--- a/cmd/grove/testdata/script/remove_branch_unmerged.txt
+++ b/cmd/grove/testdata/script/remove_branch_unmerged.txt
@@ -1,4 +1,4 @@
-# Test: grove remove --branch fails for unmerged commits
+# Test: unmerged branches are rejected before removing their worktrees
 setup_workspace branch-unmerged
 
 exec grove add branch-unmerged
@@ -8,30 +8,23 @@ exec git add newfile.txt
 exec git commit -m 'unmerged commit'
 cd ../main
 
-# Branch has commits not merged to main, so git branch -d fails
 ! exec grove remove --branch branch-unmerged
-stderr '✗ .*not fully merged'
-stderr 'Removed worktree.*branch-unmerged'
+stderr 'branch-unmerged: branch is not merged into main; use --force to delete anyway'
+stderr 'failed: branch-unmerged'
+! stderr 'Removed worktree'
+exists ../branch-unmerged/newfile.txt
+exec git show-ref --verify refs/heads/branch-unmerged
 
-# Worktree was removed but branch deletion failed
-! exists ../branch-unmerged
-exec git branch --list branch-unmerged
-stdout 'branch-unmerged'
-
-# Multi-worktree summary only claims a branch deletion that succeeded
+# An unmerged target fails without blocking a merged target in the batch.
 exec grove add branch-merged
-exec grove add branch-unmerged
-cd ../branch-unmerged
-cp $WORK/newfile.txt second.txt
-exec git add second.txt
-exec git commit -m 'second unmerged commit'
-cd ../main
 ! exec grove remove --branch branch-merged branch-unmerged
-stderr 'Removed 2 worktrees:'
-stderr 'branch-merged \(branch branch-merged\)'
-! stderr 'branch-unmerged \(branch'
-exec git branch --list branch-unmerged
-stdout 'branch-unmerged'
+stderr 'Removed worktree.*branch-merged'
+stderr 'deleted branch branch-merged'
+stderr 'failed: branch-unmerged'
+! exists ../branch-merged
+! exec git show-ref --verify refs/heads/branch-merged
+exists ../branch-unmerged/newfile.txt
+exec git show-ref --verify refs/heads/branch-unmerged
 
 -- newfile.txt --
 new content

--- a/cmd/grove/testdata/script/remove_branch_unpushed.txt
+++ b/cmd/grove/testdata/script/remove_branch_unpushed.txt
@@ -19,17 +19,18 @@ exec git add local-change.txt
 exec git commit -m 'unpushed local commit'
 cd ../main
 
-# Remove with --branch warns about unpushed but fails branch delete (not merged to main)
+# Refuse deletion before removing the unmerged worktree.
 ! exec grove remove --branch unpushed-test
-stderr 'unpushed'
-stderr '✗ .*not fully merged'
+stderr 'unpushed-test: branch is not merged into main; use --force to delete anyway'
+exists ../unpushed-test
 
-# Worktree was removed
+# Once merged, deletion still warns about commits not pushed to the upstream.
+exec git merge unpushed-test
+exec grove remove --branch unpushed-test
+stderr 'branch has 1 unpushed commit\(s\)'
 ! exists ../unpushed-test
 
-# Branch still exists
-exec git branch --list unpushed-test
-stdout 'unpushed-test'
+! exec git show-ref --verify refs/heads/unpushed-test
 
 -- local-change.txt --
 local only

--- a/cmd/grove/testdata/script/remove_ignore_missing.txt
+++ b/cmd/grove/testdata/script/remove_ignore_missing.txt
@@ -1,0 +1,31 @@
+# Test: missing targets abort validation unless --ignore-missing is set
+setup_workspace a b
+exec grove add a
+exec grove add b
+
+! exec grove remove a nope b
+stderr 'worktree not found: nope'
+! stderr 'Removed'
+exists ../a
+exists ../b
+
+exec grove remove --ignore-missing a nope b a
+stderr -count=1 'nope: not found \(skipped\)'
+stderr 'Removed 2 worktrees:'
+! exists ../a
+! exists ../b
+exec git show-ref --verify refs/heads/a
+exec git show-ref --verify refs/heads/b
+
+# All missing targets are a successful no-op, with one warning per name.
+exec grove remove --ignore-missing nope nope absent
+stderr -count=1 'nope: not found \(skipped\)'
+stderr -count=1 'absent: not found \(skipped\)'
+! stderr 'Removed'
+
+# The flag does not suppress failures for worktrees that exist.
+! exec grove remove --ignore-missing nope main
+stderr 'nope: not found \(skipped\)'
+stderr 'cannot delete current worktree'
+stderr 'failed: main'
+exists ../main


### PR DESCRIPTION
**`grove remove --branch` now refuses to delete an unmerged branch instead of stranding it without its worktree.**

Merge state used to be checked by `git branch -d` after the worktree was already gone, so a rejected deletion left the repo half-torn-down, and squash-merged branches were rejected outright because Git cannot see a squash as an ancestor. The check now runs before anything is removed, against the default branch, and a branch that passes it is force-deleted so squash merges delete cleanly. A batch removal can also opt into tolerating names that do not exist.

#### Changes

- `remove --branch` resolves the default branch once, then checks each branch before removing its worktree. An unmerged branch is refused with `use --force to delete anyway`, counted as failed, and left untouched along with its worktree.
- A branch that passes the merge check is deleted with force, so squash-merged branches are removed rather than rejected. `--force` is unchanged and still prints the unpushed-commit warning.
- New `--ignore-missing` skips unknown targets with one warning each instead of aborting the batch; without it, an unknown name still errors before anything is removed. Real failures still set a non-zero exit.
- A merge check that cannot run degrades to Git's own safe delete and a debug line, matching `prune`, so repos whose default branch resolves only through `origin/` keep working.

#### Test plan

- [x] Code review by Claude Opus 5 (cape:code-reviewer) on 855f698, findings addressed or dismissed
- [x] `make ci` passes: lint, unit tests, 810 integration tests, build
- [x] Unmerged branch without `--force` is refused, worktree and branch survive, exit non-zero
- [x] Same with `--force` still removes the worktree, deletes the branch, and warns about unpushed commits
- [x] Squash-merged branch is removed and deleted despite not being an ancestor of the default branch
- [x] `remove a nope b` still errors before removing anything; `--ignore-missing` removes `a` and `b`, warns once for `nope`, and still exits non-zero when a real removal fails
- [x] Unresolvable and remote-only default branches fall back to `git branch -d` behavior

---

Fixes ABU-276, AI-68
