### PR TITLE
feat: record PR identity at add time and show it in list

### DIFF
--- a/.changes/unreleased/added-AI-165.yaml
+++ b/.changes/unreleased/added-AI-165.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Show recorded PR numbers in grove list --json and --verbose, and select PR worktrees with --filter pr, including in fast mode.
+time: 2026-09-10T16:58:21.027646168+02:00

--- a/.changes/unreleased/added-AI-67.yaml
+++ b/.changes/unreleased/added-AI-67.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Record same-repository PR numbers on branches when adding or cloning PR worktrees.
+time: 2026-09-10T16:44:25.38443223+02:00

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ List all worktrees with status.
 - `--filter <status>` — Filter by `dirty`, `ahead`, `behind`, `gone`, `locked`, or `pr`. Comma-separated filters use OR. `locked` and `pr` work with `--fast`.
 - `--json` — JSON output. Includes `pr` when a PR number is recorded and `last_commit` when commit times are known (omitted with `--fast`).
 - `--sort name|recent` — Sort by name or latest commit (`recent` needs commit times, so it cannot be combined with `--fast`)
-- `-v, --verbose` — Show a PR column (`#42`, blank without a recorded PR), paths, and upstreams. PR numbers come from local config; `list` stays offline.
+- `-v, --verbose` — Show paths, upstreams, and a PR column (`#42`) when any worktree has a recorded PR number, blank on the rows without one. PR numbers come from local config; `list` stays offline.
 
 **Examples:**
 

--- a/README.md
+++ b/README.md
@@ -270,10 +270,10 @@ List all worktrees with status.
 **Flags:**
 
 - `--fast` — Skip dirty and sync status checks
-- `--filter <status>` — Filter by: `dirty`, `ahead`, `behind`, `gone`, `locked`
-- `--json` — JSON output; includes `last_commit` when commit times are known (omitted with `--fast`)
+- `--filter <status>`: Filter by `dirty`, `ahead`, `behind`, `gone`, `locked`, or `pr`. Comma-separated filters use OR. `locked` and `pr` work with `--fast`.
+- `--json`: JSON output. Includes `pr` when a PR number is recorded and `last_commit` when commit times are known (omitted with `--fast`).
 - `--sort name|recent` — Sort by name or latest commit (`recent` needs commit times, so it cannot be combined with `--fast`)
-- `-v, --verbose` — Show paths and upstreams
+- `-v, --verbose`: Show a PR column (`#42`, blank without a recorded PR), paths, and upstreams. PR numbers come from local config; `list` stays offline.
 
 **Examples:**
 
@@ -282,6 +282,7 @@ grove list
 grove list --fast
 grove list --filter dirty
 grove list --filter ahead,behind
+grove list --filter pr
 grove list --json
 grove list --sort recent
 ```

--- a/README.md
+++ b/README.md
@@ -270,10 +270,10 @@ List all worktrees with status.
 **Flags:**
 
 - `--fast` — Skip dirty and sync status checks
-- `--filter <status>`: Filter by `dirty`, `ahead`, `behind`, `gone`, `locked`, or `pr`. Comma-separated filters use OR. `locked` and `pr` work with `--fast`.
-- `--json`: JSON output. Includes `pr` when a PR number is recorded and `last_commit` when commit times are known (omitted with `--fast`).
+- `--filter <status>` — Filter by `dirty`, `ahead`, `behind`, `gone`, `locked`, or `pr`. Comma-separated filters use OR. `locked` and `pr` work with `--fast`.
+- `--json` — JSON output. Includes `pr` when a PR number is recorded and `last_commit` when commit times are known (omitted with `--fast`).
 - `--sort name|recent` — Sort by name or latest commit (`recent` needs commit times, so it cannot be combined with `--fast`)
-- `-v, --verbose`: Show a PR column (`#42`, blank without a recorded PR), paths, and upstreams. PR numbers come from local config; `list` stays offline.
+- `-v, --verbose` — Show a PR column (`#42`, blank without a recorded PR), paths, and upstreams. PR numbers come from local config; `list` stays offline.
 
 **Examples:**
 

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -562,6 +563,11 @@ func checkoutPR(bareDir, worktreePath string, ref *github.PRRef, prInfo *github.
 	if err := git.CreateWorktree(bareDir, worktreePath, git.CreateWorktreeOptions{Branch: branch}, quiet); err != nil {
 		return git.HintGitTooOld(fmt.Errorf("failed to create worktree: %w", err))
 	}
+
+	if err := git.SetBranchConfig(bareDir, branch, "grovePr", strconv.Itoa(ref.Number)); err != nil {
+		logger.Debug("Failed to record PR for %s: %v", branch, err)
+	}
+
 	if existingWorkspace {
 		if err := git.SetUpstreamBranch(worktreePath, "origin/"+branch); err != nil {
 			logger.Debug("Failed to set upstream for %s: %v", branch, err)

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -406,7 +406,15 @@ func runAddFromPR(prRef string, switchTo bool, name, bareDir, workspaceRoot, sou
 	for _, info := range infos {
 		if info.Branch == branch {
 			if !prInfo.IsFork {
-				return refreshExistingPRWorktree(bareDir, info.Path, branch, reset, switchTo)
+				if err := refreshExistingPRWorktree(bareDir, info.Path, branch, reset, switchTo); err != nil {
+					return err
+				}
+
+				if err := git.SetBranchConfig(bareDir, branch, "grovePr", strconv.Itoa(ref.Number)); err != nil {
+					logger.Debug("Failed to record PR for %s: %v", branch, err)
+				}
+
+				return nil
 			}
 			return fmt.Errorf("worktree already exists for branch %q at %s\n\nHint: Use 'grove list' to see existing worktrees, or use --name to choose a different directory", branch, info.Path)
 		}

--- a/cmd/grove/commands/add_pr_test.go
+++ b/cmd/grove/commands/add_pr_test.go
@@ -1,0 +1,42 @@
+package commands
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sqve/grove/internal/github"
+	testgit "github.com/sqve/grove/internal/testutil/git"
+)
+
+func TestCheckoutPRRecordsNumber(t *testing.T) {
+	for _, existingWorkspace := range []bool{true, false} {
+		name := "clone"
+		if existingWorkspace {
+			name = "add"
+		}
+		t.Run(name, func(t *testing.T) {
+			remote := testgit.NewTestRepo(t)
+			remote.CreateBranch("Feature/topic.v2")
+			remotePath := filepath.Join(remote.TempDir, "remote.git")
+			remote.RunOutput("clone", "--bare", remote.Path, remotePath)
+			bareDir := filepath.Join(remote.TempDir, "workspace.git")
+			remote.RunOutput("clone", "--bare", remotePath, bareDir)
+			worktreePath := filepath.Join(remote.TempDir, "pr-42")
+			reference, err := github.ParsePRReference("https://github.com/owner/repo/pull/42")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = checkoutPR(bareDir, worktreePath, reference, &github.PRInfo{HeadRef: "Feature/topic.v2"}, true, false, existingWorkspace)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			number := strings.TrimSpace(remote.RunOutput("-C", bareDir, "config", "--get", "branch.Feature/topic.v2.grovePr"))
+			if number != "42" {
+				t.Fatalf("PR number = %q, want 42", number)
+			}
+		})
+	}
+}

--- a/cmd/grove/commands/add_pr_test.go
+++ b/cmd/grove/commands/add_pr_test.go
@@ -3,15 +3,22 @@ package commands
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/sqve/grove/internal/fs"
 	"github.com/sqve/grove/internal/git"
 	"github.com/sqve/grove/internal/github"
+	"github.com/sqve/grove/internal/testutil"
 	testgit "github.com/sqve/grove/internal/testutil/git"
 )
 
 func TestRunAddFromPRRecordsNumberOnRefresh(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell gh stub is not executable on Windows")
+	}
+
 	remote := testgit.NewTestRepo(t)
 	remote.CreateBranch("Feature/topic.v2")
 	remotePath := filepath.Join(remote.TempDir, "remote.git")
@@ -26,9 +33,7 @@ func TestRunAddFromPRRecordsNumberOnRefresh(t *testing.T) {
 if [ "$1" = auth ]; then exit 0; fi
 printf '%s\n' '{"headRefName":"Feature/topic.v2","headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"owner"}}'
 `
-	if err := os.WriteFile(ghPath, []byte(ghScript), 0o700); err != nil { //nolint:gosec // The gh stub must be executable.
-		t.Fatal(err)
-	}
+	testutil.WriteFileMode(t, ghPath, ghScript, fs.FileExec)
 
 	t.Setenv("PATH", filepath.Dir(ghPath)+string(os.PathListSeparator)+os.Getenv("PATH"))
 

--- a/cmd/grove/commands/add_pr_test.go
+++ b/cmd/grove/commands/add_pr_test.go
@@ -1,13 +1,50 @@
 package commands
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/sqve/grove/internal/git"
 	"github.com/sqve/grove/internal/github"
 	testgit "github.com/sqve/grove/internal/testutil/git"
 )
+
+func TestRunAddFromPRRecordsNumberOnRefresh(t *testing.T) {
+	remote := testgit.NewTestRepo(t)
+	remote.CreateBranch("Feature/topic.v2")
+	remotePath := filepath.Join(remote.TempDir, "remote.git")
+	remote.RunOutput("clone", "--bare", remote.Path, remotePath)
+	bareDir := filepath.Join(remote.TempDir, "workspace.git")
+	remote.RunOutput("clone", "--bare", remotePath, bareDir)
+	worktreePath := filepath.Join(remote.TempDir, "existing")
+	remote.RunOutput("-C", bareDir, "worktree", "add", worktreePath, "Feature/topic.v2")
+
+	ghPath := filepath.Join(t.TempDir(), "gh")
+	ghScript := `#!/bin/sh
+if [ "$1" = auth ]; then exit 0; fi
+printf '%s\n' '{"headRefName":"Feature/topic.v2","headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"owner"}}'
+`
+	if err := os.WriteFile(ghPath, []byte(ghScript), 0o700); err != nil { //nolint:gosec // The gh stub must be executable.
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", filepath.Dir(ghPath)+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	err := runAddFromPR("https://github.com/owner/repo/pull/42", false, "", bareDir, remote.TempDir, worktreePath, false, func() {})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configs, err := git.GetBranchConfigs(bareDir, "grovePr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if configs["Feature/topic.v2"] != "42" {
+		t.Fatalf("PR number = %q, want 42", configs["Feature/topic.v2"])
+	}
+}
 
 func TestCheckoutPRRecordsNumber(t *testing.T) {
 	for _, existingWorkspace := range []bool{true, false} {

--- a/cmd/grove/commands/list.go
+++ b/cmd/grove/commands/list.go
@@ -224,12 +224,8 @@ func outputTable(infos []*git.WorktreeInfo, currentPath string, fast, verbose bo
 
 		displayInfo := *info
 		if fast {
-			// Fast mode has no sync status, even when an upstream exists.
+			// Hide the sync indicator because fast mode skips upstream checks.
 			displayInfo.NoUpstream = true
-			displayInfo.Dirty = false
-			displayInfo.Ahead = 0
-			displayInfo.Behind = 0
-			displayInfo.Gone = false
 		}
 
 		// Print the worktree row using the formatter
@@ -249,6 +245,10 @@ func outputTable(infos []*git.WorktreeInfo, currentPath string, fast, verbose bo
 		if verbose {
 			subItems := formatter.VerboseSubItems(&displayInfo)
 			for _, item := range subItems {
+				if maxPRLen > 0 {
+					item = strings.Repeat(" ", maxPRLen+2) + item
+				}
+
 				fmt.Println(item)
 			}
 		}

--- a/cmd/grove/commands/list.go
+++ b/cmd/grove/commands/list.go
@@ -22,10 +22,11 @@ import (
 const (
 	sortRecent   = "recent"
 	filterLocked = "locked"
+	filterPR     = "pr"
 )
 
 var (
-	validFilters = []string{"dirty", "ahead", "behind", "gone", filterLocked}
+	validFilters = []string{"dirty", "ahead", "behind", "gone", filterLocked, filterPR}
 	validSorts   = []string{"name", sortRecent}
 )
 
@@ -47,7 +48,7 @@ Examples:
   grove list --fast           # Skip dirty and sync status checks
   grove list --filter dirty   # Show only dirty worktrees
   grove list --sort recent    # Show most recently committed worktrees first
-  grove list --verbose        # Include paths and upstreams`,
+  grove list --verbose        # Include PR numbers, paths, and upstreams`,
 		Args: cobra.NoArgs,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return nil, cobra.ShellCompDirectiveNoFileComp
@@ -59,8 +60,8 @@ Examples:
 
 	cmd.Flags().BoolVar(&fast, "fast", false, "Skip dirty and sync status checks")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
-	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show paths and upstream names")
-	cmd.Flags().StringVar(&filter, "filter", "", "Filter by status (valid: dirty, ahead, behind, gone, locked; comma-separated)")
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show PR numbers, paths, and upstream names")
+	cmd.Flags().StringVar(&filter, "filter", "", "Filter by status (valid: dirty, ahead, behind, gone, locked, pr; comma-separated)")
 	cmd.Flags().StringVar(&sortBy, "sort", "name", "Sort order (valid: name, recent)")
 	cmd.Flags().BoolP("help", "h", false, "Help for list")
 
@@ -83,7 +84,7 @@ func runList(fast, jsonOutput, verbose bool, filter, sortBy string) error {
 	}
 	if fast {
 		for _, f := range filters {
-			if f != filterLocked {
+			if f != filterLocked && f != filterPR {
 				return fmt.Errorf("--filter %s cannot be used with --fast because status checks are skipped", f)
 			}
 		}
@@ -132,6 +133,7 @@ func runList(fast, jsonOutput, verbose bool, filter, sortBy string) error {
 }
 
 type worktreeJSON struct {
+	PR         int    `json:"pr,omitempty"`
 	Name       string `json:"name"`
 	Branch     string `json:"branch,omitempty"`
 	Path       string `json:"path"`
@@ -152,6 +154,7 @@ func outputJSON(infos []*git.WorktreeInfo, currentPath string) error {
 	output := []worktreeJSON{}
 	for _, info := range infos {
 		entry := worktreeJSON{
+			PR:         info.PR,
 			Name:       filepath.Base(info.Path),
 			Path:       info.Path,
 			Current:    fs.PathsEqual(info.Path, currentPath),
@@ -196,7 +199,12 @@ func outputTable(infos []*git.WorktreeInfo, currentPath string, fast, verbose bo
 	// Calculate max widths for padding
 	maxNameLen := 0
 	maxBranchLen := 0
+	maxPRLen := 0
 	for _, info := range infos {
+		if verbose && info.PR > 0 {
+			maxPRLen = max(maxPRLen, len(fmt.Sprintf("#%d", info.PR)))
+		}
+
 		nameLen := len(filepath.Base(info.Path))
 		if nameLen > maxNameLen {
 			maxNameLen = nameLen
@@ -214,26 +222,32 @@ func outputTable(infos []*git.WorktreeInfo, currentPath string, fast, verbose bo
 	for _, info := range infos {
 		isCurrent := fs.PathsEqual(info.Path, currentPath)
 
-		// In fast mode, we don't have sync status - create a copy with zeroed sync info
-		displayInfo := info
+		displayInfo := *info
 		if fast {
-			displayInfo = &git.WorktreeInfo{
-				Branch:     info.Branch,
-				Path:       info.Path,
-				Upstream:   info.Upstream,
-				Locked:     info.Locked,
-				LockReason: info.LockReason,
-				Detached:   info.Detached,
-				NoUpstream: true, // This prevents showing sync status
-			}
+			// Fast mode has no sync status, even when an upstream exists.
+			displayInfo.NoUpstream = true
+			displayInfo.Dirty = false
+			displayInfo.Ahead = 0
+			displayInfo.Behind = 0
+			displayInfo.Gone = false
 		}
 
 		// Print the worktree row using the formatter
-		fmt.Println(formatter.WorktreeRow(displayInfo, isCurrent, maxNameLen, maxBranchLen))
+		row := formatter.WorktreeRow(&displayInfo, isCurrent, maxNameLen, maxBranchLen)
+		if verbose && maxPRLen > 0 {
+			pr := ""
+			if displayInfo.PR > 0 {
+				pr = fmt.Sprintf("#%d", displayInfo.PR)
+			}
+
+			row = fmt.Sprintf("%-*s  %s", maxPRLen, pr, row)
+		}
+
+		fmt.Println(row)
 
 		// Print verbose sub-items
 		if verbose {
-			subItems := formatter.VerboseSubItems(displayInfo)
+			subItems := formatter.VerboseSubItems(&displayInfo)
 			for _, item := range subItems {
 				fmt.Println(item)
 			}
@@ -292,6 +306,10 @@ func matchesAnyFilter(info *git.WorktreeInfo, filters []string) bool {
 			}
 		case "gone":
 			if info.Gone {
+				return true
+			}
+		case filterPR:
+			if info.PR > 0 {
 				return true
 			}
 		case filterLocked:

--- a/cmd/grove/commands/list_test.go
+++ b/cmd/grove/commands/list_test.go
@@ -65,6 +65,7 @@ func TestParseFilters(t *testing.T) {
 		expected []string
 	}{
 		{"single filter", "dirty", []string{"dirty"}},
+		{"PR filter", "PR", []string{"pr"}},
 		{"multiple filters", "dirty,locked", []string{"dirty", "locked"}},
 		{"with spaces", " dirty , locked ", []string{"dirty", "locked"}},
 		{"empty string", "", nil},
@@ -91,7 +92,7 @@ func TestParseFilters(t *testing.T) {
 		if err == nil {
 			t.Fatalf("parseFilters(\"dirty,bogus\") = %v, want error", got)
 		}
-		want := `unknown filter "bogus" (valid: dirty, ahead, behind, gone, locked)`
+		want := `unknown filter "bogus" (valid: dirty, ahead, behind, gone, locked, pr)`
 		if err.Error() != want {
 			t.Errorf("error = %q, want %q", err.Error(), want)
 		}
@@ -194,7 +195,7 @@ func TestCompleteFilterValues(t *testing.T) {
 		{
 			name:       "empty returns all filters",
 			toComplete: "",
-			wantLen:    5,
+			wantLen:    6,
 			wantFirst:  "dirty",
 		},
 		{
@@ -212,7 +213,7 @@ func TestCompleteFilterValues(t *testing.T) {
 		{
 			name:       "after comma returns remaining filters",
 			toComplete: "dirty,",
-			wantLen:    4,
+			wantLen:    5,
 			wantFirst:  "dirty,ahead",
 		},
 		{
@@ -224,7 +225,7 @@ func TestCompleteFilterValues(t *testing.T) {
 		{
 			name:       "multiple selected excludes them",
 			toComplete: "dirty,ahead,",
-			wantLen:    3,
+			wantLen:    4,
 		},
 	}
 

--- a/cmd/grove/testdata/script/list_completion_filter.txt
+++ b/cmd/grove/testdata/script/list_completion_filter.txt
@@ -7,6 +7,17 @@ stdout 'locked'
 stdout 'ahead'
 stdout 'behind'
 stdout 'gone'
+stdout '^pr$'
+
+exec grove __complete list --filter 'dirty,p'
+stdout '^dirty,pr$'
+
+exec grove __complete list --filter 'pr,'
+! stdout '^pr,pr$'
+stdout '^pr,locked$'
+
+exec grove list --help
+stdout 'gone, locked, pr'
 
 # Partial filter filters suggestions
 exec grove __complete list --filter 'd'

--- a/cmd/grove/testdata/script/list_filter_invalid.txt
+++ b/cmd/grove/testdata/script/list_filter_invalid.txt
@@ -1,4 +1,4 @@
 # Test: grove list --filter rejects unknown values before listing
 ! exec grove list --filter bogus --plain
-stderr '^Error: unknown filter "bogus" \(valid: dirty, ahead, behind, gone, locked\)$'
+stderr '^Error: unknown filter "bogus" \(valid: dirty, ahead, behind, gone, locked, pr\)$'
 ! stdout .

--- a/cmd/grove/testdata/script/list_filter_pr.txt
+++ b/cmd/grove/testdata/script/list_filter_pr.txt
@@ -1,0 +1,30 @@
+# PR filtering stays offline and combines with status filters using OR.
+setup_workspace feat clean
+exec grove add feat
+exec grove add clean
+exec git config branch.feat.grovePr 7
+
+exec grove list --filter pr --plain
+stdout 'feat'
+! stdout 'main'
+! stdout 'clean'
+
+exec grove list --filter pr,locked --plain
+stdout 'feat'
+stdout 'main'
+! stdout 'clean'
+
+exec grove list --filter pr --fast --json
+stdout '"name": "feat"'
+stdout '"pr": 7'
+! stdout '"name": "main"'
+! stdout '"name": "clean"'
+
+exec grove list --filter pr,locked --fast --plain
+stdout 'feat'
+stdout 'main'
+! stdout 'clean'
+
+exec git config --unset branch.feat.grovePr
+exec grove list --filter pr --json
+stdout '^\[\]$'

--- a/cmd/grove/testdata/script/list_pr.txt
+++ b/cmd/grove/testdata/script/list_pr.txt
@@ -1,0 +1,14 @@
+# Recorded PR numbers appear in JSON and are omitted on other rows.
+setup_workspace feat
+exec grove add feat
+exec git config branch.feat.grovePr 7
+
+exec grove list --json
+stdout -count=1 '"pr": 7'
+! stdout '"pr": 0'
+
+exec grove list --json --filter locked
+! stdout '"pr":'
+
+exec grove list --plain
+! stdout '#7'

--- a/cmd/grove/testdata/script/list_pr_verbose.txt
+++ b/cmd/grove/testdata/script/list_pr_verbose.txt
@@ -11,14 +11,14 @@ stdout '^ +\* main +\[main\]'
 exec git config branch.feat.grovePr 12345
 exec grove list -v --plain
 stdout '^#12345 +feat +\[feat\]'
-stdout '^            > path: .*[/]feat$'
-stdout '^            > path: .*[/]main$'
+stdout '^            > path: .*[/\\]feat$'
+stdout '^            > path: .*[/\\]main$'
 ! stdout '^    > path:'
 
 exec grove list --verbose --fast --plain
 stdout '^#12345 +feat +\[feat\]'
 stdout '^ +\* main +\[main\]'
-stdout '^            > path: .*[/]feat$'
-stdout '^            > path: .*[/]main$'
+stdout '^            > path: .*[/\\]feat$'
+stdout '^            > path: .*[/\\]main$'
 ! stdout '^    > path:'
 ! stdout '#0'

--- a/cmd/grove/testdata/script/list_pr_verbose.txt
+++ b/cmd/grove/testdata/script/list_pr_verbose.txt
@@ -8,7 +8,17 @@ stdout '^#7 +feat +\[feat\]'
 stdout '^ +\* main +\[main\]'
 ! stdout '#0'
 
+exec git config branch.feat.grovePr 12345
+exec grove list -v --plain
+stdout '^#12345 +feat +\[feat\]'
+stdout '^            > path: .*[/]feat$'
+stdout '^            > path: .*[/]main$'
+! stdout '^    > path:'
+
 exec grove list --verbose --fast --plain
-stdout '^#7 +feat +\[feat\]'
+stdout '^#12345 +feat +\[feat\]'
 stdout '^ +\* main +\[main\]'
+stdout '^            > path: .*[/]feat$'
+stdout '^            > path: .*[/]main$'
+! stdout '^    > path:'
 ! stdout '#0'

--- a/cmd/grove/testdata/script/list_pr_verbose.txt
+++ b/cmd/grove/testdata/script/list_pr_verbose.txt
@@ -1,0 +1,14 @@
+# Verbose output has a PR column, including in fast mode.
+setup_workspace feat
+exec grove add feat
+exec git config branch.feat.grovePr 7
+
+exec grove list -v --plain
+stdout '^#7 +feat +\[feat\]'
+stdout '^ +\* main +\[main\]'
+! stdout '#0'
+
+exec grove list --verbose --fast --plain
+stdout '^#7 +feat +\[feat\]'
+stdout '^ +\* main +\[main\]'
+! stdout '#0'

--- a/internal/git/gitconfig.go
+++ b/internal/git/gitconfig.go
@@ -95,6 +95,8 @@ func SetConfig(key, value string, global bool) error {
 
 // SetBranchConfig sets a branch value in the repository's local config.
 func SetBranchConfig(bareDir, branch, key, value string) error {
+	logger.Debug("Setting git config: branch.%s.%s=%s (repo=%s)", branch, key, value, bareDir)
+
 	if bareDir == "" || branch == "" || key == "" {
 		return errors.New("repository path, branch and config key cannot be empty")
 	}
@@ -109,6 +111,8 @@ func SetBranchConfig(bareDir, branch, key, value string) error {
 
 // GetBranchConfigs reads a config value for all branches in one command.
 func GetBranchConfigs(bareDir, key string) (map[string]string, error) {
+	logger.Debug("Getting git configs with branch key: %s (repo=%s)", key, bareDir)
+
 	if bareDir == "" || key == "" {
 		return nil, errors.New("repository path and config key cannot be empty")
 	}

--- a/internal/git/gitconfig.go
+++ b/internal/git/gitconfig.go
@@ -93,6 +93,51 @@ func SetConfig(key, value string, global bool) error {
 	return err
 }
 
+// SetBranchConfig sets a branch value in the repository's local config.
+func SetBranchConfig(bareDir, branch, key, value string) error {
+	if bareDir == "" || branch == "" || key == "" {
+		return errors.New("repository path, branch and config key cannot be empty")
+	}
+
+	cmd, cancel := GitCommand("git", configCommand, "--local", "branch."+branch+"."+key, value)
+	defer cancel()
+	cmd.Dir = bareDir
+
+	_, err := executeWithOutput(cmd)
+	return err
+}
+
+// GetBranchConfigs reads a config value for all branches in one command.
+func GetBranchConfigs(bareDir, key string) (map[string]string, error) {
+	if bareDir == "" || key == "" {
+		return nil, errors.New("repository path and config key cannot be empty")
+	}
+
+	suffix := "." + strings.ToLower(key)
+	cmd, cancel := GitCommand("git", configCommand, "--local", "--get-regexp", "^branch\\..+"+regexp.QuoteMeta(suffix)+"$")
+	defer cancel()
+	cmd.Dir = bareDir
+	output, err := executeWithOutput(cmd)
+	configs := make(map[string]string)
+	if err != nil {
+		if cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == 1 {
+			return configs, nil
+		}
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		name, value, found := strings.Cut(scanner.Text(), " ")
+		if found {
+			branch := strings.TrimSuffix(strings.TrimPrefix(name, "branch."), suffix)
+			configs[branch] = value
+		}
+	}
+
+	return configs, scanner.Err()
+}
+
 // UnsetConfig removes a config key and all its values
 func UnsetConfig(key string, global bool) error {
 	logger.Debug("Unsetting git config: %s (global=%v)", key, global)

--- a/internal/git/gitconfig_test.go
+++ b/internal/git/gitconfig_test.go
@@ -14,34 +14,79 @@ func TestBranchConfigs(t *testing.T) {
 	repo.RunOutput("clone", "--bare", repo.Path, bareDir)
 	t.Chdir(repo.Path)
 
-	configs, err := GetBranchConfigs(bareDir, "grovePr")
-	if err != nil || len(configs) != 0 {
-		t.Fatalf("empty configs = %v, %v", configs, err)
-	}
-	for _, branch := range []string{"Feature/topic.v2", "main"} {
-		if err := SetBranchConfig(bareDir, branch, "grovePr", "41"); err != nil {
-			t.Fatal(err)
-		}
-		if err := SetBranchConfig(bareDir, branch, "grovePr", "42"); err != nil {
-			t.Fatal(err)
-		}
-	}
-	repo.RunOutput("-C", bareDir, "config", "branch.main.grovePrExtra", "99")
-	repo.RunOutput("config", "branch.main.grovePr", "100")
+	t.Run("returns an empty map when no keys match", func(t *testing.T) {
+		configs, err := GetBranchConfigs(bareDir, "grovePr")
 
-	configs, err = GetBranchConfigs(bareDir, "grovePr")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(configs) != 2 || configs["Feature/topic.v2"] != "42" || configs["main"] != "42" {
-		t.Fatalf("configs = %v", configs)
-	}
-	if _, err := GetBranchConfigs(bareDir+"/missing", "grovePr"); err == nil {
-		t.Fatal("expected read failure")
-	}
-	if err := SetBranchConfig(bareDir+"/missing", "main", "grovePr", "42"); err == nil {
-		t.Fatal("expected write failure")
-	}
+		if err != nil || len(configs) != 0 {
+			t.Fatalf("empty configs = %v, %v", configs, err)
+		}
+	})
+
+	t.Run("overwrites values and preserves branch names", func(t *testing.T) {
+		for _, branch := range []string{"Feature/topic.v2", "main"} {
+			if err := SetBranchConfig(bareDir, branch, "grovePr", "41"); err != nil {
+				t.Fatal(err)
+			}
+			if err := SetBranchConfig(bareDir, branch, "grovePr", "42"); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		configs, err := GetBranchConfigs(bareDir, "grovePr")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(configs) != 2 || configs["Feature/topic.v2"] != "42" || configs["main"] != "42" {
+			t.Fatalf("configs = %v", configs)
+		}
+	})
+
+	t.Run("excludes other keys", func(t *testing.T) {
+		repo := testgit.NewTestRepo(t)
+		repo.RunOutput("config", "branch.main.grovePrExtra", "99")
+
+		configs, err := GetBranchConfigs(repo.Path, "grovePr")
+
+		if err != nil || len(configs) != 0 {
+			t.Fatalf("configs = %v, %v", configs, err)
+		}
+	})
+
+	t.Run("reads and writes the requested repository regardless of cwd", func(t *testing.T) {
+		repo.RunOutput("config", "branch.main.grovePr", "100")
+		if err := SetBranchConfig(bareDir, "main", "grovePr", "42"); err != nil {
+			t.Fatal(err)
+		}
+
+		configs, err := GetBranchConfigs(bareDir, "grovePr")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if configs["main"] != "42" {
+			t.Fatalf("configs = %v", configs)
+		}
+		if value := repo.RunOutput("config", "branch.main.grovePr"); value != "100\n" {
+			t.Fatalf("cwd config = %q, want 100", value)
+		}
+	})
+
+	t.Run("reports read failures", func(t *testing.T) {
+		_, err := GetBranchConfigs(bareDir+"/missing", "grovePr")
+
+		if err == nil {
+			t.Fatal("expected read failure")
+		}
+	})
+
+	t.Run("reports write failures", func(t *testing.T) {
+		err := SetBranchConfig(bareDir+"/missing", "main", "grovePr", "42")
+
+		if err == nil {
+			t.Fatal("expected write failure")
+		}
+	})
 }
 
 func TestGetConfigs(t *testing.T) {

--- a/internal/git/gitconfig_test.go
+++ b/internal/git/gitconfig_test.go
@@ -8,6 +8,42 @@ import (
 	testgit "github.com/sqve/grove/internal/testutil/git"
 )
 
+func TestBranchConfigs(t *testing.T) {
+	repo := testgit.NewTestRepo(t)
+	bareDir := repo.TempDir + "/bare.git"
+	repo.RunOutput("clone", "--bare", repo.Path, bareDir)
+	t.Chdir(repo.Path)
+
+	configs, err := GetBranchConfigs(bareDir, "grovePr")
+	if err != nil || len(configs) != 0 {
+		t.Fatalf("empty configs = %v, %v", configs, err)
+	}
+	for _, branch := range []string{"Feature/topic.v2", "main"} {
+		if err := SetBranchConfig(bareDir, branch, "grovePr", "41"); err != nil {
+			t.Fatal(err)
+		}
+		if err := SetBranchConfig(bareDir, branch, "grovePr", "42"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	repo.RunOutput("-C", bareDir, "config", "branch.main.grovePrExtra", "99")
+	repo.RunOutput("config", "branch.main.grovePr", "100")
+
+	configs, err = GetBranchConfigs(bareDir, "grovePr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(configs) != 2 || configs["Feature/topic.v2"] != "42" || configs["main"] != "42" {
+		t.Fatalf("configs = %v", configs)
+	}
+	if _, err := GetBranchConfigs(bareDir+"/missing", "grovePr"); err == nil {
+		t.Fatal("expected read failure")
+	}
+	if err := SetBranchConfig(bareDir+"/missing", "main", "grovePr", "42"); err == nil {
+		t.Fatal("expected write failure")
+	}
+}
+
 func TestGetConfigs(t *testing.T) {
 	t.Run("only matches keys starting with exact prefix", func(t *testing.T) {
 		repo := testgit.NewTestRepo(t)

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/sqve/grove/internal/fs"
@@ -16,6 +17,7 @@ import (
 
 // WorktreeInfo contains status information about a worktree
 type WorktreeInfo struct {
+	PR             int    `json:"-"`
 	Path           string `json:"path"`                  // Absolute path to worktree
 	Branch         string `json:"branch"`                // Branch name (or commit hash if detached)
 	Upstream       string `json:"upstream,omitempty"`    // Upstream branch name (e.g., "origin/main")
@@ -302,6 +304,11 @@ func ListWorktreesWithInfo(bareDir string, fast bool) ([]*WorktreeInfo, error) {
 		return nil, err
 	}
 
+	branchPRs, err := GetBranchConfigs(bareDir, "grovePr")
+	if err != nil {
+		logger.Debug("Failed to read branch PR numbers: %v", err)
+	}
+
 	var infos []*WorktreeInfo
 	for _, entry := range entries {
 		path := entry.Path
@@ -334,6 +341,13 @@ func ListWorktreesWithInfo(bareDir string, fast bool) ([]*WorktreeInfo, error) {
 				if info, ok = worktreeFallbackInfo(path, entry, err); !ok {
 					continue
 				}
+			}
+		}
+
+		if !info.Detached {
+			number, err := strconv.Atoi(branchPRs[info.Branch])
+			if err == nil && number > 0 {
+				info.PR = number
 			}
 		}
 

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -501,6 +501,41 @@ func TestGetWorktreeInfo(t *testing.T) {
 	})
 }
 
+func TestListWorktreesWithInfoPR(t *testing.T) {
+	repo := testgit.NewTestRepo(t)
+	bareDir := filepath.Join(repo.TempDir, "bare.git")
+	repo.RunOutput("clone", "--bare", repo.Path, bareDir)
+	for _, branch := range []string{"Feature/topic.v2", "missing", "invalid", "negative", "overflow"} {
+		repo.RunOutput("-C", bareDir, "worktree", "add", filepath.Join(repo.TempDir, branch), "-b", branch)
+	}
+	repo.RunOutput("-C", bareDir, "config", "branch.Feature/topic.v2.grovePr", "42")
+	repo.RunOutput("-C", bareDir, "config", "branch.invalid.grovePr", "not-a-number")
+	repo.RunOutput("-C", bareDir, "config", "branch.negative.grovePr", "-2")
+	repo.RunOutput("-C", bareDir, "config", "branch.overflow.grovePr", "9999999999999999999999999")
+	repo.RunOutput("-C", bareDir, "worktree", "add", "--detach", filepath.Join(repo.TempDir, "detached"), "main")
+	t.Chdir(repo.Path)
+	repo.RunOutput("config", "branch.Feature/topic.v2.grovePr", "99")
+
+	for _, fast := range []bool{true, false} {
+		infos, err := ListWorktreesWithInfo(bareDir, fast)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(infos) != 6 {
+			t.Fatalf("got %d worktrees", len(infos))
+		}
+		for _, info := range infos {
+			want := 0
+			if info.Branch == "Feature/topic.v2" {
+				want = 42
+			}
+			if info.PR != want {
+				t.Errorf("fast=%v branch=%s PR=%d, want %d", fast, info.Branch, info.PR, want)
+			}
+		}
+	}
+}
+
 func TestListWorktreesWithInfo(t *testing.T) {
 	t.Run("returns worktree info for repo with worktrees", func(t *testing.T) {
 		repo := testgit.NewTestRepo(t)

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -505,34 +505,56 @@ func TestListWorktreesWithInfoPR(t *testing.T) {
 	repo := testgit.NewTestRepo(t)
 	bareDir := filepath.Join(repo.TempDir, "bare.git")
 	repo.RunOutput("clone", "--bare", repo.Path, bareDir)
+
 	for _, branch := range []string{"Feature/topic.v2", "missing", "invalid", "negative", "overflow"} {
 		repo.RunOutput("-C", bareDir, "worktree", "add", filepath.Join(repo.TempDir, branch), "-b", branch)
 	}
+
 	repo.RunOutput("-C", bareDir, "config", "branch.Feature/topic.v2.grovePr", "42")
 	repo.RunOutput("-C", bareDir, "config", "branch.invalid.grovePr", "not-a-number")
 	repo.RunOutput("-C", bareDir, "config", "branch.negative.grovePr", "-2")
 	repo.RunOutput("-C", bareDir, "config", "branch.overflow.grovePr", "9999999999999999999999999")
 	repo.RunOutput("-C", bareDir, "worktree", "add", "--detach", filepath.Join(repo.TempDir, "detached"), "main")
+
 	t.Chdir(repo.Path)
 	repo.RunOutput("config", "branch.Feature/topic.v2.grovePr", "99")
 
 	for _, fast := range []bool{true, false} {
-		infos, err := ListWorktreesWithInfo(bareDir, fast)
-		if err != nil {
-			t.Fatal(err)
+		name := "reads PR numbers from the bare repository in full mode"
+		if fast {
+			name = "reads PR numbers from the bare repository in fast mode"
 		}
-		if len(infos) != 6 {
-			t.Fatalf("got %d worktrees", len(infos))
-		}
-		for _, info := range infos {
-			want := 0
-			if info.Branch == "Feature/topic.v2" {
-				want = 42
+
+		t.Run(name, func(t *testing.T) {
+			infos, err := ListWorktreesWithInfo(bareDir, fast)
+			if err != nil {
+				t.Fatal(err)
 			}
-			if info.PR != want {
-				t.Errorf("fast=%v branch=%s PR=%d, want %d", fast, info.Branch, info.PR, want)
+
+			if len(infos) != 6 {
+				t.Fatalf("got %d worktrees", len(infos))
 			}
-		}
+
+			for _, info := range infos {
+				name := "ignores " + info.Branch + " PR numbers"
+				if info.Detached {
+					name = "leaves detached worktrees without a PR number"
+				} else if info.Branch == "Feature/topic.v2" {
+					name = "preserves mixed-case branch names with dots and slashes"
+				}
+
+				t.Run(name, func(t *testing.T) {
+					want := 0
+					if info.Branch == "Feature/topic.v2" {
+						want = 42
+					}
+
+					if info.PR != want {
+						t.Errorf("branch=%s PR=%d, want %d", info.Branch, info.PR, want)
+					}
+				})
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
**Grove now remembers which pull request a worktree came from, and `list` can show and filter on it.**

`grove add --pr` left no record of a worktree's origin: only the directory name hinted at it, and `--name` erased even that, so anything downstream had to re-query GitHub or parse paths. The number now lands in `branch.<b>.grovePr` in the bare repository config, where git carries it across branch renames for free, and `list` reads it back offline in a single config call.

#### Decisions

- Only same-repository PRs get the key. The fork path checks out a detached worktree with no local branch, so there is no `branch.<b>` to write to; forks get it when they move onto real branches.
- The number is stored alone, without owner or remote, because `WorktreeInfo.Upstream` already identifies the fork remote.
- Re-running `grove add --pr` on an existing worktree records the key as well, so worktrees created before this change become visible to `--filter pr` without being recreated.

#### Changes

- `grove add --pr` and `grove clone <pr-url>` write the PR number to the branch in the bare repository config, on both fresh checkouts and re-runs of an existing worktree. A failed write is a debug message, never an error.
- New repository-scoped git config helpers read and write branch keys against the bare directory, so listing works from any worktree.
- Worktree listing loads every recorded PR number in one `git config --get-regexp` pass, in both fast and full modes.
- `list --json` gains a `pr` field, omitted where no number is recorded; `list -v` gains a PR column; `list --filter pr` selects only worktrees with a recorded number, composing with the existing filters.

#### Test plan

- [x] Code review by Claude Opus 5 (cape:code-reviewer) on f4dbdb5, findings addressed or dismissed
- [x] `make ci` — 845 tests, lint clean, integration tests and build pass
- [x] `grove add --pr` on a same-repository PR records the number, verified against a local bare remote rather than a mocked `gh`
- [x] Re-running `grove add --pr` on an existing worktree records the number instead of silently skipping it
- [x] `list --json` carries `"pr": 7` for a seeded branch and omits the field elsewhere; `list -v` shows `#7`; `list --filter pr` returns only that row
- [x] Verbose sub-items stay aligned under the name column with a five-digit PR number
- [x] Fork PRs and plain `grove add` are unchanged

#### Deferred verification

- End-to-end `grove add --pr <n>` against a live GitHub same-repository PR. The tests exercise the checkout path against a local bare remote, so the real `gh` round trip is not covered pre-merge.

---

Fixes ABU-270, AI-56