### PR TITLE
feat(prune): target any base branch, exit non-zero on failures, add --json

### DIFF
--- a/.changes/unreleased/added-HjC4iUNd.yaml
+++ b/.changes/unreleased/added-HjC4iUNd.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Add `prune --json` for dry runs and return a non-zero exit status when pruning fails.
+time: 2026-09-10T19:52:43.929065138+02:00
+custom:
+  Issue: ''

--- a/.changes/unreleased/changed-AI-166.yaml
+++ b/.changes/unreleased/changed-AI-166.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: '`grove prune --merged` accepts a target branch as `--merged=<branch>`, so merged candidates can be selected against any base branch.'
+time: 2026-09-11T08:55:00+02:00

--- a/README.md
+++ b/README.md
@@ -422,8 +422,9 @@ When removing worktrees whose upstream was deleted on remote, local branches are
 - `--commit` — Actually remove (default is dry-run)
 - `-f, --force` — Remove even if dirty, locked, or unpushed
 - `--stale <duration>` — Include inactive worktrees (e.g., `30d`, `2w`)
-- `--merged` — Include branches merged into default branch
+- `--merged[=<branch>]` — Include branches merged into `<branch>`, defaulting to the default branch
 - `--detached` — Include detached worktrees
+- `--json` — Print the dry run as a JSON array (dry run only)
 
 **Examples:**
 
@@ -432,7 +433,9 @@ grove prune          # Dry-run
 grove prune --commit # Actually remove
 grove prune --stale 30d --commit
 grove prune --merged --commit
+grove prune --merged=develop --commit # The = is required when naming a branch
 grove prune --detached --commit
+grove prune --json   # Dry run as JSON
 ```
 
 </details>

--- a/cmd/grove/commands/prune.go
+++ b/cmd/grove/commands/prune.go
@@ -85,6 +85,12 @@ Examples:
 			if cmd.Flags().Changed("stale") && stale == "" {
 				stale = config.GetStaleThreshold()
 			}
+
+			// Bare --merged becomes the sentinel, so an empty value here means
+			// the user passed --merged= and a script expanded nothing into it.
+			if cmd.Flags().Changed("merged") && merged == "" {
+				return fmt.Errorf("--merged requires a branch name")
+			}
 			return runPrune(commit, force, stale, merged, detached, jsonOutput)
 		},
 	}
@@ -105,25 +111,62 @@ Examples:
 	return cmd
 }
 
-// resolveMergedTarget maps the --merged flag value to the branch that drives
-// candidate selection. An empty result means the flag was not passed.
-func resolveMergedTarget(bareDir, merged, defaultBranch string) (string, error) {
+// mergedTarget names the branch that --merged selects against. ref is what git
+// resolves for the merge check; branch is the plain name a worktree is checked
+// out on, which is what the candidate exclusion compares.
+type mergedTarget struct {
+	ref    string
+	branch string
+}
+
+// resolveMergedTarget maps the --merged flag value to its target, preferring a
+// local branch and falling back to a remote one so a branch that exists only on
+// the remote still resolves. An empty result means the flag was not passed.
+func resolveMergedTarget(bareDir, merged, defaultBranch string) (mergedTarget, error) {
 	if merged == "" {
-		return "", nil
+		return mergedTarget{}, nil
 	}
+
+	// The default branch is derived rather than typed, so it keeps its old
+	// behavior: an unresolvable one yields no candidates instead of an error.
 	if merged == mergedDefaultTarget {
-		return defaultBranch, nil
+		return mergedTarget{ref: defaultBranch, branch: defaultBranch}, nil
 	}
 
-	exists, err := git.BranchExists(bareDir, merged)
+	// Accept the remote-qualified form users reach for, e.g. origin/develop.
+	if remote, branch, found := strings.Cut(merged, "/"); found {
+		exists, err := git.RemoteBranchExists(bareDir, remote, branch)
+		if err != nil {
+			return mergedTarget{}, fmt.Errorf("failed to check branch %q: %w", merged, err)
+		}
+		if exists {
+			return mergedTarget{ref: merged, branch: branch}, nil
+		}
+	}
+
+	local, err := git.LocalBranchExists(bareDir, merged)
 	if err != nil {
-		return "", fmt.Errorf("failed to check branch %q: %w", merged, err)
+		return mergedTarget{}, fmt.Errorf("failed to check branch %q: %w", merged, err)
 	}
-	if !exists {
-		return "", fmt.Errorf("branch not found: %s", merged)
+	if local {
+		return mergedTarget{ref: merged, branch: merged}, nil
 	}
 
-	return merged, nil
+	remotes, err := git.ListRemotes(bareDir)
+	if err != nil {
+		return mergedTarget{}, fmt.Errorf("failed to list remotes: %w", err)
+	}
+	for _, remote := range remotes {
+		exists, remoteErr := git.RemoteBranchExists(bareDir, remote, merged)
+		if remoteErr != nil {
+			return mergedTarget{}, fmt.Errorf("failed to check branch %q: %w", merged, remoteErr)
+		}
+		if exists {
+			return mergedTarget{ref: remote + "/" + merged, branch: merged}, nil
+		}
+	}
+
+	return mergedTarget{}, fmt.Errorf("branch not found: %s", merged)
 }
 
 func runPrune(commit, force bool, stale, merged string, detached, jsonOutput bool) error {
@@ -171,7 +214,7 @@ func runPrune(commit, force bool, stale, merged string, detached, jsonOutput boo
 		}
 	}
 
-	mergedTarget, err := resolveMergedTarget(bareDir, merged, defaultBranch)
+	target, err := resolveMergedTarget(bareDir, merged, defaultBranch)
 	if err != nil {
 		return err
 	}
@@ -224,9 +267,12 @@ func runPrune(commit, force bool, stale, merged string, detached, jsonOutput boo
 
 		// Check for merged (only if --merged flag was passed). The default-branch
 		// and target-branch worktrees are never candidates for their own merge.
-		if mergedTarget != "" && info.Branch != "" && info.Branch != defaultBranch && info.Branch != mergedTarget {
-			isMerged, mergeErr := git.IsBranchMerged(bareDir, info.Branch, mergedTarget)
-			if mergeErr == nil && isMerged {
+		if target.ref != "" && info.Branch != "" && info.Branch != defaultBranch && info.Branch != target.branch {
+			isMerged, mergeErr := git.IsBranchMerged(bareDir, info.Branch, target.ref)
+			if mergeErr != nil {
+				// Say so rather than silently reporting no candidates.
+				logger.Warning("Could not check whether %s is merged into %s: %v", info.Branch, target.ref, mergeErr)
+			} else if isMerged {
 				reason := determineSkipReason(info, cwd, force)
 				candidates = append(candidates, pruneCandidate{
 					info:      info,

--- a/cmd/grove/commands/prune.go
+++ b/cmd/grove/commands/prune.go
@@ -48,12 +48,16 @@ type pruneCandidate struct {
 	staleAge  string // Human-readable age for stale worktrees
 }
 
+// mergedDefaultTarget is the --merged value Cobra substitutes when the flag is
+// passed without one. The spaces make it impossible to collide with a branch name.
+const mergedDefaultTarget = "<default branch>"
+
 // NewPruneCmd creates the prune command
 func NewPruneCmd() *cobra.Command {
 	var commit bool
 	var force bool
 	var stale string
-	var merged bool
+	var merged string
 	var detached bool
 	var jsonOutput bool
 
@@ -68,7 +72,8 @@ Examples:
   grove prune                 # Dry-run: show what would be removed
   grove prune --commit        # Actually remove worktrees
   grove prune --stale 30d     # Include inactive worktrees
-  grove prune --merged        # Include merged branches
+  grove prune --merged        # Include branches merged into the default branch
+  grove prune --merged=dev    # Include branches merged into dev (the = is required)
   grove prune --detached      # Include detached worktrees
   grove prune --force         # Remove even if dirty or locked`,
 		Args: cobra.NoArgs,
@@ -87,7 +92,8 @@ Examples:
 	cmd.Flags().BoolVar(&commit, "commit", false, "Remove worktrees (dry-run without this flag)")
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Remove even if dirty, locked, or unpushed")
 	cmd.Flags().StringVar(&stale, "stale", "", fmt.Sprintf("Include inactive worktrees (e.g., 30d, 2w; default: %s)", config.GetStaleThreshold()))
-	cmd.Flags().BoolVar(&merged, "merged", false, "Include worktrees merged into default branch")
+	cmd.Flags().StringVar(&merged, "merged", "", "Include worktrees merged into a branch (default: the default branch; use --merged=<branch>)")
+	cmd.Flags().Lookup("merged").NoOptDefVal = mergedDefaultTarget
 	cmd.Flags().BoolVar(&detached, "detached", false, "Include detached worktrees")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output dry run as JSON")
 	cmd.Flags().BoolP("help", "h", false, "Help for prune")
@@ -99,7 +105,28 @@ Examples:
 	return cmd
 }
 
-func runPrune(commit, force bool, stale string, merged, detached, jsonOutput bool) error {
+// resolveMergedTarget maps the --merged flag value to the branch that drives
+// candidate selection. An empty result means the flag was not passed.
+func resolveMergedTarget(bareDir, merged, defaultBranch string) (string, error) {
+	if merged == "" {
+		return "", nil
+	}
+	if merged == mergedDefaultTarget {
+		return defaultBranch, nil
+	}
+
+	exists, err := git.BranchExists(bareDir, merged)
+	if err != nil {
+		return "", fmt.Errorf("failed to check branch %q: %w", merged, err)
+	}
+	if !exists {
+		return "", fmt.Errorf("branch not found: %s", merged)
+	}
+
+	return merged, nil
+}
+
+func runPrune(commit, force bool, stale, merged string, detached, jsonOutput bool) error {
 	if jsonOutput && commit {
 		return fmt.Errorf("--json applies to dry run only")
 	}
@@ -138,10 +165,15 @@ func runPrune(commit, force bool, stale string, merged, detached, jsonOutput boo
 	defaultBranch, defaultBranchErr := git.GetDefaultBranch(bareDir)
 	if defaultBranchErr != nil {
 		logger.Debug("Could not determine default branch: %v", defaultBranchErr)
-		if merged {
+		if merged == mergedDefaultTarget {
 			logger.Warning("Could not determine default branch, skipping --merged check")
-			merged = false // Disable merged check if we can't determine default branch
+			merged = "" // Disable merged check if we can't determine default branch
 		}
+	}
+
+	mergedTarget, err := resolveMergedTarget(bareDir, merged, defaultBranch)
+	if err != nil {
+		return err
 	}
 
 	// Get all worktrees with info
@@ -190,9 +222,10 @@ func runPrune(commit, force bool, stale string, merged, detached, jsonOutput boo
 			continue // Don't double-count as merged or stale
 		}
 
-		// Check for merged (only if --merged flag was passed)
-		if merged && info.Branch != "" && info.Branch != defaultBranch {
-			isMerged, mergeErr := git.IsBranchMerged(bareDir, info.Branch, defaultBranch)
+		// Check for merged (only if --merged flag was passed). The default-branch
+		// and target-branch worktrees are never candidates for their own merge.
+		if mergedTarget != "" && info.Branch != "" && info.Branch != defaultBranch && info.Branch != mergedTarget {
+			isMerged, mergeErr := git.IsBranchMerged(bareDir, info.Branch, mergedTarget)
 			if mergeErr == nil && isMerged {
 				reason := determineSkipReason(info, cwd, force)
 				candidates = append(candidates, pruneCandidate{

--- a/cmd/grove/commands/prune.go
+++ b/cmd/grove/commands/prune.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -53,6 +55,7 @@ func NewPruneCmd() *cobra.Command {
 	var stale string
 	var merged bool
 	var detached bool
+	var jsonOutput bool
 
 	cmd := &cobra.Command{
 		Use:   "prune",
@@ -77,7 +80,7 @@ Examples:
 			if cmd.Flags().Changed("stale") && stale == "" {
 				stale = config.GetStaleThreshold()
 			}
-			return runPrune(commit, force, stale, merged, detached)
+			return runPrune(commit, force, stale, merged, detached, jsonOutput)
 		},
 	}
 
@@ -86,6 +89,7 @@ Examples:
 	cmd.Flags().StringVar(&stale, "stale", "", fmt.Sprintf("Include inactive worktrees (e.g., 30d, 2w; default: %s)", config.GetStaleThreshold()))
 	cmd.Flags().BoolVar(&merged, "merged", false, "Include worktrees merged into default branch")
 	cmd.Flags().BoolVar(&detached, "detached", false, "Include detached worktrees")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output dry run as JSON")
 	cmd.Flags().BoolP("help", "h", false, "Help for prune")
 
 	_ = cmd.RegisterFlagCompletionFunc("stale", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -95,7 +99,11 @@ Examples:
 	return cmd
 }
 
-func runPrune(commit, force bool, stale string, merged, detached bool) error {
+func runPrune(commit, force bool, stale string, merged, detached, jsonOutput bool) error {
+	if jsonOutput && commit {
+		return fmt.Errorf("--json applies to dry run only")
+	}
+
 	// Parse stale threshold if provided
 	var staleCutoff int64
 	if stale != "" {
@@ -212,6 +220,10 @@ func runPrune(commit, force bool, stale string, merged, detached bool) error {
 	if commit {
 		return executePrune(bareDir, candidates, force, defaultBranch)
 	}
+	if jsonOutput {
+		return outputPruneJSON(candidates)
+	}
+
 	return displayDryRun(candidates)
 }
 
@@ -238,6 +250,34 @@ func determineSkipReason(info *git.WorktreeInfo, cwd string, force bool) skipRea
 	}
 
 	return skipNone
+}
+
+type pruneJSON struct {
+	Name       string     `json:"name"`
+	Path       string     `json:"path"`
+	Branch     string     `json:"branch"`
+	Reason     pruneType  `json:"reason"`
+	SkipReason skipReason `json:"skip_reason"`
+	StaleAge   string     `json:"stale_age"`
+}
+
+func outputPruneJSON(candidates []pruneCandidate) error {
+	output := make([]pruneJSON, 0, len(candidates))
+	for _, candidate := range candidates {
+		output = append(output, pruneJSON{
+			Name:       filepath.Base(candidate.info.Path),
+			Path:       candidate.info.Path,
+			Branch:     candidate.info.Branch,
+			Reason:     candidate.pruneType,
+			SkipReason: candidate.reason,
+			StaleAge:   candidate.staleAge,
+		})
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+
+	return encoder.Encode(output)
 }
 
 func displayDryRun(candidates []pruneCandidate) error {
@@ -488,6 +528,8 @@ func executePrune(bareDir string, candidates []pruneCandidate, force bool, defau
 		for _, item := range failed {
 			logger.Dimmed("    %s", item)
 		}
+
+		return fmt.Errorf("failed to prune %d worktree(s)", len(failed))
 	}
 
 	return nil

--- a/cmd/grove/commands/prune.go
+++ b/cmd/grove/commands/prune.go
@@ -121,7 +121,9 @@ type mergedTarget struct {
 
 // resolveMergedTarget maps the --merged flag value to its target, preferring a
 // local branch and falling back to a remote one so a branch that exists only on
-// the remote still resolves. An empty result means the flag was not passed.
+// the remote still resolves. The ref is fully qualified, since a short name like
+// origin/develop is ambiguous when a local branch of that name also exists.
+// An empty result means the flag was not passed.
 func resolveMergedTarget(bareDir, merged, defaultBranch string) (mergedTarget, error) {
 	if merged == "" {
 		return mergedTarget{}, nil
@@ -140,7 +142,7 @@ func resolveMergedTarget(bareDir, merged, defaultBranch string) (mergedTarget, e
 		return mergedTarget{}, fmt.Errorf("failed to check branch %q: %w", merged, err)
 	}
 	if local {
-		return mergedTarget{ref: merged, branch: merged}, nil
+		return mergedTarget{ref: "refs/heads/" + merged, branch: merged}, nil
 	}
 
 	// Accept the remote-qualified form users reach for, e.g. origin/develop.
@@ -150,7 +152,7 @@ func resolveMergedTarget(bareDir, merged, defaultBranch string) (mergedTarget, e
 			return mergedTarget{}, fmt.Errorf("failed to check branch %q: %w", merged, cutErr)
 		}
 		if exists {
-			return mergedTarget{ref: merged, branch: branch}, nil
+			return mergedTarget{ref: "refs/remotes/" + merged, branch: branch}, nil
 		}
 	}
 
@@ -164,7 +166,7 @@ func resolveMergedTarget(bareDir, merged, defaultBranch string) (mergedTarget, e
 			return mergedTarget{}, fmt.Errorf("failed to check branch %q: %w", merged, remoteErr)
 		}
 		if exists {
-			return mergedTarget{ref: remote + "/" + merged, branch: merged}, nil
+			return mergedTarget{ref: "refs/remotes/" + remote + "/" + merged, branch: merged}, nil
 		}
 	}
 

--- a/cmd/grove/commands/prune.go
+++ b/cmd/grove/commands/prune.go
@@ -133,23 +133,25 @@ func resolveMergedTarget(bareDir, merged, defaultBranch string) (mergedTarget, e
 		return mergedTarget{ref: defaultBranch, branch: defaultBranch}, nil
 	}
 
-	// Accept the remote-qualified form users reach for, e.g. origin/develop.
-	if remote, branch, found := strings.Cut(merged, "/"); found {
-		exists, err := git.RemoteBranchExists(bareDir, remote, branch)
-		if err != nil {
-			return mergedTarget{}, fmt.Errorf("failed to check branch %q: %w", merged, err)
-		}
-		if exists {
-			return mergedTarget{ref: merged, branch: branch}, nil
-		}
-	}
-
+	// A local branch wins, the way git prefers refs/heads over refs/remotes. A
+	// branch named feature/foo must not be read as remote "feature", branch "foo".
 	local, err := git.LocalBranchExists(bareDir, merged)
 	if err != nil {
 		return mergedTarget{}, fmt.Errorf("failed to check branch %q: %w", merged, err)
 	}
 	if local {
 		return mergedTarget{ref: merged, branch: merged}, nil
+	}
+
+	// Accept the remote-qualified form users reach for, e.g. origin/develop.
+	if remote, branch, found := strings.Cut(merged, "/"); found {
+		exists, cutErr := git.RemoteBranchExists(bareDir, remote, branch)
+		if cutErr != nil {
+			return mergedTarget{}, fmt.Errorf("failed to check branch %q: %w", merged, cutErr)
+		}
+		if exists {
+			return mergedTarget{ref: merged, branch: branch}, nil
+		}
 	}
 
 	remotes, err := git.ListRemotes(bareDir)

--- a/cmd/grove/commands/prune_test.go
+++ b/cmd/grove/commands/prune_test.go
@@ -39,6 +39,16 @@ func TestNewPruneCmd(t *testing.T) {
 	}
 }
 
+func TestPruneJSONCommitConflict(t *testing.T) {
+	cmd := NewPruneCmd()
+	cmd.SetArgs([]string{"--json", "--commit"})
+
+	err := cmd.Execute()
+	if err == nil || err.Error() != "--json applies to dry run only" {
+		t.Fatalf("expected JSON commit conflict, got: %v", err)
+	}
+}
+
 func TestRunPrune(t *testing.T) {
 	t.Run("returns error when not in workspace", func(t *testing.T) {
 		// Save and restore cwd
@@ -47,7 +57,7 @@ func TestRunPrune(t *testing.T) {
 		tmpDir := testutil.TempDir(t)
 		testutil.Chdir(t, tmpDir)
 
-		err := runPrune(false, false, "", false, false)
+		err := runPrune(false, false, "", false, false, false)
 		if err == nil {
 			t.Error("expected error for non-workspace directory")
 		}

--- a/cmd/grove/commands/prune_test.go
+++ b/cmd/grove/commands/prune_test.go
@@ -57,7 +57,7 @@ func TestRunPrune(t *testing.T) {
 		tmpDir := testutil.TempDir(t)
 		testutil.Chdir(t, tmpDir)
 
-		err := runPrune(false, false, "", false, false, false)
+		err := runPrune(false, false, "", "", false, false)
 		if err == nil {
 			t.Error("expected error for non-workspace directory")
 		}

--- a/cmd/grove/testdata/script/prune_failed_exit.txt
+++ b/cmd/grove/testdata/script/prune_failed_exit.txt
@@ -1,0 +1,14 @@
+# Test: prune failures keep the summary and exit with status 1
+[windows] skip 'requires Unix directory permissions'
+setup_workspace feature-gone
+
+exec grove add feature-gone
+exec git -C $WORK/testrepo branch -D feature-gone
+
+# Restore permissions before assertions so cleanup also works on failure.
+exec chmod 0555 $WORK/workspace
+! exec sh -c 'grove prune --commit; status=$?; chmod 0755 "$WORK/workspace"; echo "exit status: $status"; exit "$status"'
+stdout '^exit status: 1$'
+stderr 'Failed to remove 1 worktree:'
+stderr 'feature-gone.*[Pp]ermission denied'
+stderr 'failed to prune 1 worktree\(s\)'

--- a/cmd/grove/testdata/script/prune_failed_exit.txt
+++ b/cmd/grove/testdata/script/prune_failed_exit.txt
@@ -12,3 +12,6 @@ stdout '^exit status: 1$'
 stderr 'Failed to remove 1 worktree:'
 stderr 'feature-gone.*[Pp]ermission denied'
 stderr 'failed to prune 1 worktree\(s\)'
+
+# The candidate that could not be removed is still there.
+exists ../feature-gone

--- a/cmd/grove/testdata/script/prune_json.txt
+++ b/cmd/grove/testdata/script/prune_json.txt
@@ -1,0 +1,32 @@
+# Test: prune JSON dry runs expose candidates without human-readable output
+setup_workspace feature-gone
+
+exec grove add feature-gone
+exec git -C $WORK/testrepo branch -D feature-gone
+exec grove prune --json
+stdout '^\['
+stdout '"name": "feature-gone"'
+stdout '"path": ".*/workspace/feature-gone"'
+stdout '"branch": "feature-gone"'
+stdout '"reason": "gone"'
+stdout '"skip_reason": ""'
+stdout '"stale_age": ""'
+! stdout 'Would prune|Would skip|Run with --commit|Fetching'
+exists ../feature-gone
+
+# A skipped candidate stays in the array with its existing skip reason.
+exec git -C ../feature-gone worktree lock .
+exec grove prune --json
+stdout '"skip_reason": "locked, use --force"'
+! stdout 'Would prune|Would skip|Run with --commit|Fetching'
+exec git -C ../feature-gone worktree unlock .
+
+! exec grove prune --json --commit
+stderr '\-\-json applies to dry run only'
+! stdout .
+exists ../feature-gone
+
+exec grove prune --commit
+exec grove prune --json
+stdout '^\[\]$'
+! stdout 'No worktrees'

--- a/cmd/grove/testdata/script/prune_json.txt
+++ b/cmd/grove/testdata/script/prune_json.txt
@@ -6,7 +6,7 @@ exec git -C $WORK/testrepo branch -D feature-gone
 exec grove prune --json
 stdout '^\['
 stdout '"name": "feature-gone"'
-stdout '"path": ".*/workspace/feature-gone"'
+stdout '"path": ".*workspace[/\\]+feature-gone"'
 stdout '"branch": "feature-gone"'
 stdout '"reason": "gone"'
 stdout '"skip_reason": ""'

--- a/cmd/grove/testdata/script/prune_merged_ambiguous_target.txt
+++ b/cmd/grove/testdata/script/prune_merged_ambiguous_target.txt
@@ -1,0 +1,26 @@
+# Test: a local branch named origin/<x> cannot hijack a remote --merged target
+setup_workspace topic
+
+# develop exists only on the origin, so the target resolves through refs/remotes
+exec git -C $WORK/testrepo checkout topic
+cp $WORK/topic.txt $WORK/testrepo/topic.txt
+exec git -C $WORK/testrepo add topic.txt
+exec git -C $WORK/testrepo commit -m 'topic commit'
+exec git -C $WORK/testrepo checkout -b develop main
+exec git -C $WORK/testrepo merge --no-ff topic -m 'merge topic'
+exec git -C $WORK/testrepo checkout main
+exec git -C $WORK/workspace/.bare fetch origin
+exec grove add topic
+
+# A local branch literally named origin/develop shadows the short ref: git
+# resolves refs/heads before refs/remotes. It sits on main, which topic is not
+# merged into, so an unqualified target would find no candidates at all.
+exec git -C $WORK/workspace/.bare update-ref refs/heads/origin/develop refs/heads/main
+
+# The target still resolves to the remote branch, so topic is found
+exec grove prune --merged=develop
+stderr 'Would prune 1 worktree'
+stderr 'topic'
+
+-- topic.txt --
+topic content

--- a/cmd/grove/testdata/script/prune_merged_remote_target.txt
+++ b/cmd/grove/testdata/script/prune_merged_remote_target.txt
@@ -1,0 +1,21 @@
+# Test: grove prune --merged=<branch> resolves a branch that only exists on the remote
+setup_workspace topic
+
+# develop is created on the origin after the clone, so it never exists locally
+exec git -C $WORK/testrepo checkout topic
+cp $WORK/topic.txt $WORK/testrepo/topic.txt
+exec git -C $WORK/testrepo add topic.txt
+exec git -C $WORK/testrepo commit -m 'topic commit'
+exec git -C $WORK/testrepo checkout -b develop main
+exec git -C $WORK/testrepo merge --no-ff topic -m 'merge topic'
+exec git -C $WORK/testrepo checkout main
+exec git -C $WORK/workspace/.bare fetch origin
+exec grove add topic
+
+# The target resolves through origin/develop rather than failing or matching nothing
+exec grove prune --merged=develop
+stderr 'Would prune 1 worktree'
+stderr 'topic'
+
+-- topic.txt --
+topic content

--- a/cmd/grove/testdata/script/prune_merged_slash_target.txt
+++ b/cmd/grove/testdata/script/prune_merged_slash_target.txt
@@ -1,0 +1,30 @@
+# Test: a local slash-bearing --merged target wins over a same-named remote
+setup_workspace feature/foo sub
+
+# sub is merged into feature/foo
+exec git -C $WORK/testrepo checkout sub
+cp $WORK/sub.txt $WORK/testrepo/sub.txt
+exec git -C $WORK/testrepo add sub.txt
+exec git -C $WORK/testrepo commit -m 'sub commit'
+exec git -C $WORK/testrepo checkout feature/foo
+exec git -C $WORK/testrepo merge --no-ff sub -m 'merge sub'
+exec git -C $WORK/testrepo checkout main
+
+# A second remote named "feature" carrying a branch "foo", so refs/remotes/feature/foo
+# collides with the local branch feature/foo
+exec git clone $WORK/testrepo $WORK/otherrepo
+exec git -C $WORK/otherrepo checkout -b foo
+exec git -C $WORK/workspace/.bare remote add feature file://$WORK/otherrepo
+exec git -C $WORK/workspace/.bare fetch origin
+exec git -C $WORK/workspace/.bare fetch feature
+exec grove add feature/foo
+exec grove add sub
+
+# The local branch wins, so its own worktree stays excluded
+exec grove prune --merged=feature/foo
+stderr 'Would prune 1 worktree'
+stderr 'sub'
+! stderr 'feature/foo'
+
+-- sub.txt --
+sub content

--- a/cmd/grove/testdata/script/prune_merged_target.txt
+++ b/cmd/grove/testdata/script/prune_merged_target.txt
@@ -1,5 +1,5 @@
 # Test: grove prune --merged=<branch> selects against an explicit branch
-setup_workspace develop topic
+setup_workspace develop topic spare
 
 # topic is merged into develop only, never into main
 exec git -C $WORK/testrepo checkout topic
@@ -8,14 +8,26 @@ exec git -C $WORK/testrepo add topic.txt
 exec git -C $WORK/testrepo commit -m 'topic commit'
 exec git -C $WORK/testrepo checkout develop
 exec git -C $WORK/testrepo merge --no-ff topic -m 'merge topic'
+
+# spare carries its own commit, so it is never a merged candidate
+exec git -C $WORK/testrepo checkout spare
+cp $WORK/spare.txt $WORK/testrepo/spare.txt
+exec git -C $WORK/testrepo add spare.txt
+exec git -C $WORK/testrepo commit -m 'spare commit'
 exec git -C $WORK/testrepo checkout main
 exec git -C $WORK/workspace/.bare fetch origin
 exec grove add develop
 exec grove add topic
+exec grove add spare
 
 # Bare --merged still targets the default branch, where topic is unmerged
 exec grove prune --merged
 stderr 'No worktrees to prune'
+
+# Run from spare, not from main. main is merged into develop, so only the
+# default-branch exclusion keeps it out; from main it would be skipped as the
+# current worktree and the exclusion would go untested.
+cd ../spare
 
 # --merged=develop selects the branch merged into develop
 exec grove prune --merged=develop
@@ -24,12 +36,14 @@ stderr 'topic'
 
 # Neither the default-branch nor the target-branch worktree is a candidate
 ! stderr 'develop'
+! stderr 'main'
 
 # The remote-qualified form resolves and still excludes the target worktree
 exec grove prune --merged=origin/develop
 stderr 'Would prune 1 worktree'
 stderr 'topic'
-! stderr '\bdevelop\b'
+! stderr 'develop'
+! stderr 'main'
 
 # An unknown target is rejected
 ! exec grove prune --merged=nosuchbranch
@@ -41,3 +55,5 @@ stderr '--merged requires a branch name'
 
 -- topic.txt --
 topic content
+-- spare.txt --
+spare content

--- a/cmd/grove/testdata/script/prune_merged_target.txt
+++ b/cmd/grove/testdata/script/prune_merged_target.txt
@@ -1,0 +1,33 @@
+# Test: grove prune --merged=<branch> selects against an explicit branch
+setup_workspace develop topic
+
+# topic is merged into develop only, never into main
+exec git -C $WORK/testrepo checkout topic
+cp $WORK/topic.txt $WORK/testrepo/topic.txt
+exec git -C $WORK/testrepo add topic.txt
+exec git -C $WORK/testrepo commit -m 'topic commit'
+exec git -C $WORK/testrepo checkout develop
+exec git -C $WORK/testrepo merge --no-ff topic -m 'merge topic'
+exec git -C $WORK/testrepo checkout main
+exec git -C $WORK/workspace/.bare fetch origin
+exec grove add develop
+exec grove add topic
+
+# Bare --merged still targets the default branch, where topic is unmerged
+exec grove prune --merged
+stderr 'No worktrees to prune'
+
+# --merged=develop selects the branch merged into develop
+exec grove prune --merged=develop
+stderr 'Would prune 1 worktree'
+stderr 'topic'
+
+# Neither the default-branch nor the target-branch worktree is a candidate
+! stderr 'develop'
+
+# An unknown target is rejected
+! exec grove prune --merged=nosuchbranch
+stderr 'branch not found: nosuchbranch'
+
+-- topic.txt --
+topic content

--- a/cmd/grove/testdata/script/prune_merged_target.txt
+++ b/cmd/grove/testdata/script/prune_merged_target.txt
@@ -25,9 +25,19 @@ stderr 'topic'
 # Neither the default-branch nor the target-branch worktree is a candidate
 ! stderr 'develop'
 
+# The remote-qualified form resolves and still excludes the target worktree
+exec grove prune --merged=origin/develop
+stderr 'Would prune 1 worktree'
+stderr 'topic'
+! stderr '\bdevelop\b'
+
 # An unknown target is rejected
 ! exec grove prune --merged=nosuchbranch
 stderr 'branch not found: nosuchbranch'
+
+# An empty value is rejected rather than silently skipping the check
+! exec grove prune --merged=
+stderr '--merged requires a branch name'
 
 -- topic.txt --
 topic content


### PR DESCRIPTION
**`grove prune` can now target any base branch, reports removal failures through its exit code, and exposes dry-run candidates as JSON.**

`--merged` was a bool pinned to the default branch, so anyone integrating into `develop` or a release branch could not use it at all. Pruning also printed its failures and then exited 0, which made it unsafe to script, and the dry run was human-readable text only. This lifts all three limits without touching how gone branches are force-deleted.

#### Changes

- `--merged` takes an optional branch: bare `--merged` behaves exactly as before, `--merged=develop` selects branches merged into develop. The `=` is required, via Cobra's `NoOptDefVal`.
- A target is resolved the way git resolves a ref: a local branch first, then a remote-qualified name like `origin/develop`, then the same branch on any configured remote. A branch that exists only on the remote resolves, because prune has already fetched by that point. An unknown target is an error rather than an empty result, and a merge check that fails now says so instead of silently reporting no candidates.
- Neither the default-branch worktree nor the target-branch worktree is ever a merged candidate, so `--merged=develop --commit` cannot remove develop's own worktree.
- `prune --commit` exits 1 when any removal fails, after printing the existing summary.
- `prune --json` prints the candidate array (`name`, `path`, `branch`, `reason`, `skip_reason`, `stale_age`) and nothing else on stdout, reusing the reasons the text output already uses. `--json --commit` is rejected.

#### Decisions

- Target resolution prefers a local branch over a remote one so a branch named `feature/foo` is never read as remote `feature`, branch `foo`; without that precedence a repo with a remote named after a branch prefix could prune the target's own worktree.
- The sentinel for a bare `--merged` is `<default branch>`, which contains spaces and therefore cannot collide with a real branch name.
- `--merged=` with an empty value is an error rather than a silent no-op, so an unset variable in a script fails loudly instead of reporting nothing to prune.
- `--merged=HEAD` resolves to `origin/HEAD`, i.e. the default branch. Harmless, and arguably what someone typing it means.

#### Test plan

- [x] Code review by Claude Opus 5 (cape:code-reviewer) on 4bb676c, findings addressed or dismissed
- [x] `make ci` passes
- [x] `prune_merged_target.txt`: bare `--merged` finds nothing, `--merged=develop` and `--merged=origin/develop` each select only the merged branch, the develop worktree is never listed, an unknown target and an empty `--merged=` both error
- [x] `prune_merged_remote_target.txt`: a target that exists only as `origin/develop` resolves
- [x] `prune_merged_slash_target.txt`: a local `feature/foo` wins over a remote named `feature` carrying a branch `foo`
- [x] `prune_failed_exit.txt`: an unremovable candidate keeps the summary and exits 1
- [x] `prune_json.txt`: the array, the field values, the empty `[]` case, no human-readable output on stdout, and the `--json --commit` error
- [x] Existing prune behavior is unchanged: no existing script test was modified and all of them still pass

---

Fixes ABU-266, AI-47