### PR TITLE
feat(add): open a prepared worktree in Herdr behind --herdr

### DIFF
--- a/.changes/unreleased/added-AI-168.yaml
+++ b/.changes/unreleased/added-AI-168.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Add `grove add --herdr` to open a prepared worktree in Herdr after setup and hooks succeed.
+time: 2026-09-11T11:20:03.197752219+02:00
+custom:
+  Issue: ''

--- a/.changes/unreleased/fixed-AI-171.yaml
+++ b/.changes/unreleased/fixed-AI-171.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Give grove add --herdr distinct recovery hints for missing binaries, failed exits, and existing PR worktrees, and document the flag.
+time: 2026-09-11T11:33:26.95436676+02:00
+custom:
+  Issue: ''

--- a/.changes/unreleased/fixed-AI-172.yaml
+++ b/.changes/unreleased/fixed-AI-172.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Reuse the existing worktree when grove add --herdr is run again, without repeating setup or hooks.
+time: 2026-09-11T11:46:01.691830575+02:00
+custom:
+  Issue: ''

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Add a worktree for a branch, pull request, or ref.
 **Flags:**
 
 - `-s, --switch` — Switch to the worktree; prints the path of an existing one instead of erroring
-- `--herdr`: Open the prepared worktree in Herdr after setup and hooks succeed. Requires `herdr` on PATH; cannot combine with `--switch`.
+- `--herdr` — Open the prepared worktree in Herdr after setup and hooks succeed; requires `herdr` on PATH and cannot combine with `--switch`
 - `--base <branch>` — Create new branch from this base instead of the default branch
 - `--no-fetch` — Skip fetching the base branch or the existing branch's upstream
 - `--name <name>` — Custom directory name

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Add a worktree for a branch, pull request, or ref.
 **Flags:**
 
 - `-s, --switch` — Switch to the worktree; prints the path of an existing one instead of erroring
+- `--herdr`: Open the prepared worktree in Herdr after setup and hooks succeed. Requires `herdr` on PATH; cannot combine with `--switch`.
 - `--base <branch>` — Create new branch from this base instead of the default branch
 - `--no-fetch` — Skip fetching the base branch or the existing branch's upstream
 - `--name <name>` — Custom directory name
@@ -213,6 +214,7 @@ Add a worktree for a branch, pull request, or ref.
 ```bash
 grove add feat/auth
 grove add feat/auth --switch
+grove add feat/auth --herdr    # Open in Herdr after preparation
 grove add --base main feat/auth
 grove add --pr 123             # PR by number
 grove add --pr 123 --reset     # PR, discarding local commits

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ The catch: `git worktree` is clunky. Grove makes it feel like `git checkout` —
 
 - **Git 2.48+** — Grove uses `--relative-paths` for portable worktrees
 
+Optional, each enabling one feature and never required:
+
+- **[`gh`](https://cli.github.com/)** — [PR worktrees and squash-merge detection](#optional-github-cli)
+- **`herdr`** — [opening a new worktree in a workspace](#optional-herdr)
+
 ## 📦 Installation
 
 ### Quick install (Linux/macOS)
@@ -81,6 +86,14 @@ Grove works without additional dependencies, but installing the [GitHub CLI](htt
 - **Squash-merge detection**: `grove prune` accurately detects branches merged via GitHub's squash-and-merge, even with multiple commits. Without `gh`, only single-commit squash merges are detected via git.
 
 See [GitHub CLI installation](https://github.com/cli/cli#installation) for setup instructions.
+
+### Optional: Herdr
+
+Installing `herdr`, a terminal workspace manager for AI coding agents, enables one extra feature:
+
+- **Open a worktree on creation**: `grove add feat/auth --herdr` hands the prepared worktree to Herdr, which opens and focuses a workspace for it. Re-running the command focuses the workspace that already exists.
+
+Grove only needs `herdr` on PATH. Without the flag it is never called.
 
 ## 🔧 Setup
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Add a worktree for a branch, pull request, or ref.
 **Flags:**
 
 - `-s, --switch` — Switch to the worktree; prints the path of an existing one instead of erroring
-- `--herdr` — Open the prepared worktree in Herdr after setup and hooks succeed; requires `herdr` on PATH and cannot combine with `--switch`
+- `--herdr` — Open the prepared worktree in Herdr after setup and hooks succeed; re-running it for an existing worktree hands that worktree to Herdr without repeating preserve, link, or add hooks. Requires `herdr` on PATH and cannot combine with `--switch`
 - `--base <branch>` — Create new branch from this base instead of the default branch
 - `--no-fetch` — Skip fetching the base branch or the existing branch's upstream
 - `--name <name>` — Custom directory name

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -226,7 +226,7 @@ func runAdd(args []string, switchTo, herdr bool, baseBranch, name string, detach
 // anyway; anything else leaves a worktree that may be half-synced.
 var (
 	errWorktreeDirty    = errors.New("worktree has uncommitted changes")
-	errWorktreeUnsynced = errors.New("worktree has local commits")
+	errWorktreeUnsynced = errors.New("worktree is unsynced")
 )
 
 // samePath reports whether two paths name the same worktree. git records the

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -221,6 +221,26 @@ func runAdd(args []string, switchTo, herdr bool, baseBranch, name string, detach
 	return runAddFromBranch(branchOrPR, switchTo, herdr, baseBranch, name, bareDir, workspaceRoot, sourceWorktree, releaseLock, !noFetch && config.IsFetchBase())
 }
 
+func openWorktreeInHerdr(bareDir, worktreePath string) error {
+	command := exec.Command("herdr", "worktree", "open", "--cwd", filepath.Dir(bareDir), "--path", worktreePath, "--focus") //nolint:gosec // Paths are passed as arguments, not shell commands.
+	command.Stderr = os.Stderr
+
+	if err := command.Run(); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return fmt.Errorf("worktree prepared at %s, but Herdr could not open it (ensure herdr is installed and on PATH): %w", worktreePath, err)
+		}
+
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			return fmt.Errorf("worktree prepared at %s, but Herdr exited with an error; see its output above: %w", worktreePath, err)
+		}
+
+		return fmt.Errorf("worktree prepared at %s, but Herdr could not start: %w", worktreePath, err)
+	}
+
+	return nil
+}
+
 func runAddFromBranch(branch string, switchTo, herdr bool, baseBranch, name, bareDir, workspaceRoot, sourceWorktree string, releaseLock func(), fetchBase bool) error {
 	dirName := name
 	if dirName == "" {
@@ -234,6 +254,11 @@ func runAddFromBranch(branch string, switchTo, herdr bool, baseBranch, name, bar
 	}
 	for _, info := range infos {
 		if info.Branch == branch {
+			if herdr {
+				releaseLock()
+				return openWorktreeInHerdr(bareDir, info.Path)
+			}
+
 			if switchTo {
 				logger.Info("Switching to existing worktree")
 				fmt.Println(info.Path)
@@ -350,7 +375,21 @@ func runAddDetached(ref string, switchTo, herdr bool, name, bareDir, workspaceRo
 	}
 	worktreePath := filepath.Join(workspaceRoot, dirName)
 
-	// Check directory doesn't already exist
+	// Only a registered detached worktree can be handed off without preparation.
+	if herdr {
+		infos, err := git.ListWorktreesWithInfo(bareDir, true)
+		if err != nil {
+			return fmt.Errorf("failed to list worktrees: %w", err)
+		}
+
+		for _, info := range infos {
+			if info.Detached && fs.PathsEqual(info.Path, worktreePath) {
+				releaseLock()
+				return openWorktreeInHerdr(bareDir, info.Path)
+			}
+		}
+	}
+
 	if _, err := os.Stat(worktreePath); err == nil {
 		return fmt.Errorf("directory already exists: %s", worktreePath)
 	}
@@ -414,7 +453,8 @@ func runAddFromPR(prRef string, switchTo, herdr bool, name, bareDir, workspaceRo
 	for _, info := range infos {
 		if info.Branch == branch {
 			if herdr {
-				return fmt.Errorf("--herdr: worktree already exists for branch %q at %s; open that worktree directly in Herdr", branch, info.Path)
+				releaseLock()
+				return openWorktreeInHerdr(bareDir, info.Path)
 			}
 
 			if !prInfo.IsFork {
@@ -612,20 +652,8 @@ func finishWorktree(bareDir, sourceWorktree, worktreePath, branch string, switch
 	}
 
 	if herdr {
-		command := exec.Command("herdr", "worktree", "open", "--cwd", filepath.Dir(bareDir), "--path", worktreePath, "--focus") //nolint:gosec // Paths are passed as arguments, not shell commands.
-		command.Stderr = os.Stderr
-
-		if err := command.Run(); err != nil {
-			if errors.Is(err, exec.ErrNotFound) {
-				return fmt.Errorf("worktree prepared at %s, but Herdr could not open it (ensure herdr is installed and on PATH): %w", worktreePath, err)
-			}
-
-			var exitError *exec.ExitError
-			if errors.As(err, &exitError) {
-				return fmt.Errorf("worktree prepared at %s, but Herdr exited with an error; see its output above: %w", worktreePath, err)
-			}
-
-			return fmt.Errorf("worktree prepared at %s, but Herdr could not start: %w", worktreePath, err)
+		if err := openWorktreeInHerdr(bareDir, worktreePath); err != nil {
+			return err
 		}
 	}
 

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -221,24 +221,30 @@ func runAdd(args []string, switchTo, herdr bool, baseBranch, name string, detach
 	return runAddFromBranch(branchOrPR, switchTo, herdr, baseBranch, name, bareDir, workspaceRoot, sourceWorktree, releaseLock, !noFetch && config.IsFetchBase())
 }
 
-// openWorktreeInHerdr hands worktreePath to the Herdr CLI and focuses it. The
-// state describes how the worktree got there, so a failed re-run does not claim
-// setup work this invocation never did.
-func openWorktreeInHerdr(bareDir, worktreePath, state string) error {
-	command := exec.Command("herdr", "worktree", "open", "--cwd", filepath.Dir(bareDir), "--path", worktreePath, "--focus") //nolint:gosec // Paths are passed as arguments, not shell commands.
+// openWorktreeInHerdr hands worktreePath to the Herdr CLI and focuses it. Herdr
+// keys a workspace on the checkout path, so the path is resolved first: a fresh
+// worktree carries the spelling the caller built, while a re-run carries the one
+// git recorded, and through a symlinked root those differ.
+func openWorktreeInHerdr(bareDir, worktreePath string) error {
+	canonical, err := filepath.EvalSymlinks(worktreePath)
+	if err != nil {
+		return fmt.Errorf("worktree at %s is ready, but its path could not be resolved for Herdr: %w", worktreePath, err)
+	}
+
+	command := exec.Command("herdr", "worktree", "open", "--cwd", filepath.Dir(bareDir), "--path", canonical, "--focus") //nolint:gosec // Paths are passed as arguments, not shell commands.
 	command.Stderr = os.Stderr
 
 	if err := command.Run(); err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
-			return fmt.Errorf("worktree %s at %s, but Herdr could not open it (ensure herdr is installed and on PATH): %w", state, worktreePath, err)
+			return fmt.Errorf("worktree at %s is ready, but Herdr could not open it (ensure herdr is installed and on PATH): %w", canonical, err)
 		}
 
 		var exitError *exec.ExitError
 		if errors.As(err, &exitError) {
-			return fmt.Errorf("worktree %s at %s, but Herdr exited with an error; see its output above: %w", state, worktreePath, err)
+			return fmt.Errorf("worktree at %s is ready, but Herdr exited with an error; see its output above: %w", canonical, err)
 		}
 
-		return fmt.Errorf("worktree %s at %s, but Herdr could not start: %w", state, worktreePath, err)
+		return fmt.Errorf("worktree at %s is ready, but Herdr could not start: %w", canonical, err)
 	}
 
 	return nil
@@ -259,7 +265,7 @@ func runAddFromBranch(branch string, switchTo, herdr bool, baseBranch, name, bar
 		if info.Branch == branch {
 			if herdr {
 				releaseLock()
-				return openWorktreeInHerdr(bareDir, info.Path, "exists")
+				return openWorktreeInHerdr(bareDir, info.Path)
 			}
 
 			if switchTo {
@@ -392,7 +398,9 @@ func runAddDetached(ref string, switchTo, herdr bool, name, bareDir, workspaceRo
 			return fmt.Errorf("failed to list worktrees: %w", err)
 		}
 
-		wanted, err := git.RevParse(bareDir, ref)
+		// Peel to the commit so an annotated tag compares against the commit its
+		// worktree is checked out at, not the tag object.
+		wanted, err := git.RevParse(bareDir, ref+"^{commit}")
 		if err != nil {
 			return fmt.Errorf("failed to resolve ref %q: %w", ref, err)
 		}
@@ -407,10 +415,12 @@ func runAddDetached(ref string, switchTo, herdr bool, name, bareDir, workspaceRo
 				return fmt.Errorf("failed to resolve HEAD of %s: %w", info.Path, err)
 			}
 
-			if head == wanted {
-				releaseLock()
-				return openWorktreeInHerdr(bareDir, info.Path, "exists")
+			if head != wanted {
+				return fmt.Errorf("worktree at %s is checked out at %s, not %q; remove it or pass --name to use a different directory", info.Path, head, ref)
 			}
+
+			releaseLock()
+			return openWorktreeInHerdr(bareDir, info.Path)
 		}
 	}
 
@@ -471,12 +481,9 @@ func runAddFromPR(prRef string, switchTo, herdr bool, name, bareDir, workspaceRo
 	}
 	for _, info := range infos {
 		if info.Branch == branch {
-			if herdr {
-				releaseLock()
-				return openWorktreeInHerdr(bareDir, info.Path, "exists")
-			}
-
 			if !prInfo.IsFork {
+				// Sync before any handoff, so --herdr opens the refreshed PR head
+				// rather than a stale checkout, and --reset keeps its meaning.
 				if err := refreshExistingPRWorktree(bareDir, info.Path, branch, reset, switchTo); err != nil {
 					return err
 				}
@@ -485,8 +492,19 @@ func runAddFromPR(prRef string, switchTo, herdr bool, name, bareDir, workspaceRo
 					logger.Debug("Failed to record PR for %s: %v", branch, err)
 				}
 
+				if herdr {
+					releaseLock()
+					return openWorktreeInHerdr(bareDir, info.Path)
+				}
+
 				return nil
 			}
+
+			if herdr {
+				releaseLock()
+				return openWorktreeInHerdr(bareDir, info.Path)
+			}
+
 			return fmt.Errorf("worktree already exists for branch %q at %s\n\nHint: Use 'grove list' to see existing worktrees, or use --name to choose a different directory", branch, info.Path)
 		}
 	}
@@ -671,7 +689,7 @@ func finishWorktree(bareDir, sourceWorktree, worktreePath, branch string, switch
 	}
 
 	if herdr {
-		if err := openWorktreeInHerdr(bareDir, worktreePath, "prepared"); err != nil {
+		if err := openWorktreeInHerdr(bareDir, worktreePath); err != nil {
 			return err
 		}
 	}

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -512,7 +512,16 @@ func runAddFromPR(prRef string, switchTo, herdr bool, name, bareDir, workspaceRo
 		return fmt.Errorf("failed to list worktrees: %w", err)
 	}
 	for _, info := range infos {
-		if info.Branch == branch {
+		// A fork PR is checked out from the fork's remote-tracking ref, so its
+		// worktree is detached and carries no branch to match on. Its path is the
+		// identity; matching the fork's branch name would find a local worktree
+		// that merely shares it.
+		matched := info.Branch == branch
+		if prInfo.IsFork {
+			matched = samePath(info.Path, worktreePath)
+		}
+
+		if matched {
 			if !prInfo.IsFork {
 				// The PR identity holds regardless of whether the sync below
 				// succeeds, and a worktree being worked in never syncs cleanly.

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -221,21 +221,24 @@ func runAdd(args []string, switchTo, herdr bool, baseBranch, name string, detach
 	return runAddFromBranch(branchOrPR, switchTo, herdr, baseBranch, name, bareDir, workspaceRoot, sourceWorktree, releaseLock, !noFetch && config.IsFetchBase())
 }
 
-func openWorktreeInHerdr(bareDir, worktreePath string) error {
+// openWorktreeInHerdr hands worktreePath to the Herdr CLI and focuses it. The
+// state describes how the worktree got there, so a failed re-run does not claim
+// setup work this invocation never did.
+func openWorktreeInHerdr(bareDir, worktreePath, state string) error {
 	command := exec.Command("herdr", "worktree", "open", "--cwd", filepath.Dir(bareDir), "--path", worktreePath, "--focus") //nolint:gosec // Paths are passed as arguments, not shell commands.
 	command.Stderr = os.Stderr
 
 	if err := command.Run(); err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
-			return fmt.Errorf("worktree prepared at %s, but Herdr could not open it (ensure herdr is installed and on PATH): %w", worktreePath, err)
+			return fmt.Errorf("worktree %s at %s, but Herdr could not open it (ensure herdr is installed and on PATH): %w", state, worktreePath, err)
 		}
 
 		var exitError *exec.ExitError
 		if errors.As(err, &exitError) {
-			return fmt.Errorf("worktree prepared at %s, but Herdr exited with an error; see its output above: %w", worktreePath, err)
+			return fmt.Errorf("worktree %s at %s, but Herdr exited with an error; see its output above: %w", state, worktreePath, err)
 		}
 
-		return fmt.Errorf("worktree prepared at %s, but Herdr could not start: %w", worktreePath, err)
+		return fmt.Errorf("worktree %s at %s, but Herdr could not start: %w", state, worktreePath, err)
 	}
 
 	return nil
@@ -256,7 +259,7 @@ func runAddFromBranch(branch string, switchTo, herdr bool, baseBranch, name, bar
 		if info.Branch == branch {
 			if herdr {
 				releaseLock()
-				return openWorktreeInHerdr(bareDir, info.Path)
+				return openWorktreeInHerdr(bareDir, info.Path, "exists")
 			}
 
 			if switchTo {
@@ -375,28 +378,44 @@ func runAddDetached(ref string, switchTo, herdr bool, name, bareDir, workspaceRo
 	}
 	worktreePath := filepath.Join(workspaceRoot, dirName)
 
-	// Only a registered detached worktree can be handed off without preparation.
+	// Validate ref exists
+	if err := git.RefExists(bareDir, ref); err != nil {
+		return fmt.Errorf("ref %q does not exist", ref)
+	}
+
+	// Only a registered detached worktree already sitting at ref can be handed
+	// off without preparation. Matching on path alone would focus a worktree
+	// checked out at a different commit whenever --name is given.
 	if herdr {
 		infos, err := git.ListWorktreesWithInfo(bareDir, true)
 		if err != nil {
 			return fmt.Errorf("failed to list worktrees: %w", err)
 		}
 
+		wanted, err := git.RevParse(bareDir, ref)
+		if err != nil {
+			return fmt.Errorf("failed to resolve ref %q: %w", ref, err)
+		}
+
 		for _, info := range infos {
-			if info.Detached && fs.PathsEqual(info.Path, worktreePath) {
+			if !info.Detached || !fs.PathsEqual(info.Path, worktreePath) {
+				continue
+			}
+
+			head, err := git.RevParse(info.Path, "HEAD")
+			if err != nil {
+				return fmt.Errorf("failed to resolve HEAD of %s: %w", info.Path, err)
+			}
+
+			if head == wanted {
 				releaseLock()
-				return openWorktreeInHerdr(bareDir, info.Path)
+				return openWorktreeInHerdr(bareDir, info.Path, "exists")
 			}
 		}
 	}
 
 	if _, err := os.Stat(worktreePath); err == nil {
 		return fmt.Errorf("directory already exists: %s", worktreePath)
-	}
-
-	// Validate ref exists
-	if err := git.RefExists(bareDir, ref); err != nil {
-		return fmt.Errorf("ref %q does not exist", ref)
 	}
 
 	if err := git.CreateWorktree(bareDir, worktreePath, git.CreateWorktreeOptions{Branch: ref, Detach: true}, true); err != nil {
@@ -454,7 +473,7 @@ func runAddFromPR(prRef string, switchTo, herdr bool, name, bareDir, workspaceRo
 		if info.Branch == branch {
 			if herdr {
 				releaseLock()
-				return openWorktreeInHerdr(bareDir, info.Path)
+				return openWorktreeInHerdr(bareDir, info.Path, "exists")
 			}
 
 			if !prInfo.IsFork {
@@ -652,7 +671,7 @@ func finishWorktree(bareDir, sourceWorktree, worktreePath, branch string, switch
 	}
 
 	if herdr {
-		if err := openWorktreeInHerdr(bareDir, worktreePath); err != nil {
+		if err := openWorktreeInHerdr(bareDir, worktreePath, "prepared"); err != nil {
 			return err
 		}
 	}

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -221,10 +221,14 @@ func runAdd(args []string, switchTo, herdr bool, baseBranch, name string, detach
 	return runAddFromBranch(branchOrPR, switchTo, herdr, baseBranch, name, bareDir, workspaceRoot, sourceWorktree, releaseLock, !noFetch && config.IsFetchBase())
 }
 
-// openWorktreeInHerdr hands worktreePath to the Herdr CLI and focuses it. Herdr
-// keys a workspace on the checkout path, so the path is resolved first: a fresh
-// worktree carries the spelling the caller built, while a re-run carries the one
-// git recorded, and through a symlinked root those differ.
+// A refresh can refuse for two reasons that describe the user's own in-progress
+// work rather than a broken sync. Only those are safe for --herdr to open
+// anyway; anything else leaves a worktree that may be half-synced.
+var (
+	errWorktreeDirty    = errors.New("worktree has uncommitted changes")
+	errWorktreeUnsynced = errors.New("worktree has local commits")
+)
+
 // samePath reports whether two paths name the same worktree. git records the
 // resolved path while Grove builds one from os.Getwd, which prefers $PWD, so
 // through a symlinked workspace root the two spellings differ. A path that
@@ -242,6 +246,10 @@ func samePath(a, b string) bool {
 	return fs.PathsEqual(resolve(a), resolve(b))
 }
 
+// openWorktreeInHerdr hands worktreePath to the Herdr CLI and focuses it. Herdr
+// keys a workspace on the checkout path, so the path is resolved first: a fresh
+// worktree carries the spelling the caller built, while a re-run carries the one
+// git recorded, and through a symlinked root those differ.
 func openWorktreeInHerdr(bareDir, worktreePath string) error {
 	canonical, err := filepath.EvalSymlinks(worktreePath)
 	if err != nil {
@@ -506,22 +514,26 @@ func runAddFromPR(prRef string, switchTo, herdr bool, name, bareDir, workspaceRo
 	for _, info := range infos {
 		if info.Branch == branch {
 			if !prInfo.IsFork {
+				// The PR identity holds regardless of whether the sync below
+				// succeeds, and a worktree being worked in never syncs cleanly.
+				if err := git.SetBranchConfig(bareDir, branch, "grovePr", strconv.Itoa(ref.Number)); err != nil {
+					logger.Debug("Failed to record PR for %s: %v", branch, err)
+				}
+
 				// Sync before any handoff, so --herdr opens the refreshed PR head
 				// rather than a stale checkout, and --reset keeps its meaning.
-				// A worktree being worked in is dirty by definition, so with
-				// --herdr a refusal to sync must not also refuse to open it.
 				if err := refreshExistingPRWorktree(bareDir, info.Path, branch, reset, switchTo); err != nil {
-					if !herdr {
+					// Refusing to sync work in progress must not also refuse to
+					// open it. A broken sync still aborts: the worktree may be
+					// half-synced, and opening it would hide that.
+					inProgress := errors.Is(err, errWorktreeDirty) || errors.Is(err, errWorktreeUnsynced)
+					if !herdr || !inProgress {
 						return err
 					}
 
 					logger.Warning("Opening %s without syncing it: %v", info.Path, err)
 					releaseLock()
 					return openWorktreeInHerdr(bareDir, info.Path)
-				}
-
-				if err := git.SetBranchConfig(bareDir, branch, "grovePr", strconv.Itoa(ref.Number)); err != nil {
-					logger.Debug("Failed to record PR for %s: %v", branch, err)
 				}
 
 				if herdr {
@@ -566,14 +578,14 @@ func refreshExistingPRWorktree(bareDir, worktreePath, branch string, reset, swit
 		return fmt.Errorf("failed to check worktree changes: %w", err)
 	}
 	if hasTrackedChanges {
-		return errors.New("worktree has uncommitted changes; commit or stash before refreshing")
+		return fmt.Errorf("%w; commit or stash before refreshing", errWorktreeDirty)
 	}
 	ahead, behind, err := git.CompareBranchRefs(bareDir, branch, fetchedHash)
 	if err != nil {
 		return fmt.Errorf("failed to compare branches: %w", err)
 	}
 	if ahead > 0 && !reset {
-		return fmt.Errorf("local branch %q has %d commit(s) not on remote (PR may have been rebased); use --reset to discard local commits and sync with remote", branch, ahead)
+		return fmt.Errorf("%w: local branch %q has %d commit(s) not on remote (PR may have been rebased); use --reset to discard local commits and sync with remote", errWorktreeUnsynced, branch, ahead)
 	}
 	// Move through the worktree so its index and files follow the branch.
 	switch {

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -20,9 +20,6 @@ import (
 	"github.com/sqve/grove/internal/workspace"
 )
 
-// ErrHerdrWorktreeExists means the requested PR branch already has a worktree.
-var ErrHerdrWorktreeExists = errors.New("worktree already exists")
-
 func NewAddCmd() *cobra.Command {
 	var baseBranch string
 	var name string
@@ -417,7 +414,7 @@ func runAddFromPR(prRef string, switchTo, herdr bool, name, bareDir, workspaceRo
 	for _, info := range infos {
 		if info.Branch == branch {
 			if herdr {
-				return fmt.Errorf("--herdr: %w for branch %q at %s; open that worktree directly in Herdr", ErrHerdrWorktreeExists, branch, info.Path)
+				return fmt.Errorf("--herdr: worktree already exists for branch %q at %s; open that worktree directly in Herdr", branch, info.Path)
 			}
 
 			if !prInfo.IsFork {

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -225,13 +225,37 @@ func runAdd(args []string, switchTo, herdr bool, baseBranch, name string, detach
 // keys a workspace on the checkout path, so the path is resolved first: a fresh
 // worktree carries the spelling the caller built, while a re-run carries the one
 // git recorded, and through a symlinked root those differ.
+// samePath reports whether two paths name the same worktree. git records the
+// resolved path while Grove builds one from os.Getwd, which prefers $PWD, so
+// through a symlinked workspace root the two spellings differ. A path that
+// cannot be resolved (it does not exist yet) compares as written.
+func samePath(a, b string) bool {
+	resolve := func(path string) string {
+		resolved, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			return path
+		}
+
+		return resolved
+	}
+
+	return fs.PathsEqual(resolve(a), resolve(b))
+}
+
 func openWorktreeInHerdr(bareDir, worktreePath string) error {
 	canonical, err := filepath.EvalSymlinks(worktreePath)
 	if err != nil {
 		return fmt.Errorf("worktree at %s is ready, but its path could not be resolved for Herdr: %w", worktreePath, err)
 	}
 
-	command := exec.Command("herdr", "worktree", "open", "--cwd", filepath.Dir(bareDir), "--path", canonical, "--focus") //nolint:gosec // Paths are passed as arguments, not shell commands.
+	// Both arguments must land in the same namespace: Herdr resolves the
+	// workspace from --cwd and the worktree from --path.
+	root, err := filepath.EvalSymlinks(filepath.Dir(bareDir))
+	if err != nil {
+		return fmt.Errorf("worktree at %s is ready, but the workspace root could not be resolved for Herdr: %w", canonical, err)
+	}
+
+	command := exec.Command("herdr", "worktree", "open", "--cwd", root, "--path", canonical, "--focus") //nolint:gosec // Paths are passed as arguments, not shell commands.
 	command.Stderr = os.Stderr
 
 	if err := command.Run(); err != nil {
@@ -406,7 +430,7 @@ func runAddDetached(ref string, switchTo, herdr bool, name, bareDir, workspaceRo
 		}
 
 		for _, info := range infos {
-			if !info.Detached || !fs.PathsEqual(info.Path, worktreePath) {
+			if !info.Detached || !samePath(info.Path, worktreePath) {
 				continue
 			}
 
@@ -484,8 +508,16 @@ func runAddFromPR(prRef string, switchTo, herdr bool, name, bareDir, workspaceRo
 			if !prInfo.IsFork {
 				// Sync before any handoff, so --herdr opens the refreshed PR head
 				// rather than a stale checkout, and --reset keeps its meaning.
+				// A worktree being worked in is dirty by definition, so with
+				// --herdr a refusal to sync must not also refuse to open it.
 				if err := refreshExistingPRWorktree(bareDir, info.Path, branch, reset, switchTo); err != nil {
-					return err
+					if !herdr {
+						return err
+					}
+
+					logger.Warning("Opening %s without syncing it: %v", info.Path, err)
+					releaseLock()
+					return openWorktreeInHerdr(bareDir, info.Path)
 				}
 
 				if err := git.SetBranchConfig(bareDir, branch, "grovePr", strconv.Itoa(ref.Number)); err != nil {

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -27,6 +28,7 @@ func NewAddCmd() *cobra.Command {
 	var prNumber int
 	var reset bool
 	var from string
+	var herdr bool
 
 	cmd := &cobra.Command{
 		Use:   "add [branch|PR-URL|ref]",
@@ -48,11 +50,12 @@ Examples:
 		ValidArgsFunction: completeAddArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switchTo, _ := cmd.Flags().GetBool("switch")
-			return runAdd(args, switchTo, baseBranch, name, detach, prNumber, reset, from, noFetch)
+			return runAdd(args, switchTo, herdr, baseBranch, name, detach, prNumber, reset, from, noFetch)
 		},
 	}
 
 	cmd.Flags().BoolP("switch", "s", false, "Switch to the worktree after creating it")
+	cmd.Flags().BoolVar(&herdr, "herdr", false, "Open the prepared worktree in Herdr after creating it (requires herdr on PATH)")
 	cmd.Flags().StringVar(&baseBranch, "base", "", "Create new branch from this base instead of the default branch")
 	cmd.Flags().StringVar(&name, "name", "", "Custom directory name for the worktree")
 	cmd.Flags().BoolVarP(&detach, "detach", "d", false, "Create worktree in detached HEAD state")
@@ -74,7 +77,11 @@ Examples:
 	return cmd
 }
 
-func runAdd(args []string, switchTo bool, baseBranch, name string, detach bool, prNumber int, reset bool, from string, noFetch bool) error {
+func runAdd(args []string, switchTo, herdr bool, baseBranch, name string, detach bool, prNumber int, reset bool, from string, noFetch bool) error {
+	if herdr && switchTo {
+		return fmt.Errorf("--herdr and --switch cannot be used together")
+	}
+
 	name = strings.TrimSpace(name)
 	if name == "." || name == ".." || strings.ContainsAny(name, `/\`) {
 		return fmt.Errorf("--name must be a single directory name")
@@ -196,24 +203,24 @@ func runAdd(args []string, switchTo bool, baseBranch, name string, detach bool, 
 	// Handle PR via --pr flag
 	if prFlag {
 		prRef := fmt.Sprintf("#%d", prNumber)
-		return runAddFromPR(prRef, switchTo, name, bareDir, workspaceRoot, sourceWorktree, reset, releaseLock)
+		return runAddFromPR(prRef, switchTo, herdr, name, bareDir, workspaceRoot, sourceWorktree, reset, releaseLock)
 	}
 
 	// Handle PR via URL
 	if isPRURL {
-		return runAddFromPR(branchOrPR, switchTo, name, bareDir, workspaceRoot, sourceWorktree, reset, releaseLock)
+		return runAddFromPR(branchOrPR, switchTo, herdr, name, bareDir, workspaceRoot, sourceWorktree, reset, releaseLock)
 	}
 
 	// Detached worktree
 	if detach {
-		return runAddDetached(branchOrPR, switchTo, name, bareDir, workspaceRoot, sourceWorktree, releaseLock)
+		return runAddDetached(branchOrPR, switchTo, herdr, name, bareDir, workspaceRoot, sourceWorktree, releaseLock)
 	}
 
 	// Regular branch creation
-	return runAddFromBranch(branchOrPR, switchTo, baseBranch, name, bareDir, workspaceRoot, sourceWorktree, releaseLock, !noFetch && config.IsFetchBase())
+	return runAddFromBranch(branchOrPR, switchTo, herdr, baseBranch, name, bareDir, workspaceRoot, sourceWorktree, releaseLock, !noFetch && config.IsFetchBase())
 }
 
-func runAddFromBranch(branch string, switchTo bool, baseBranch, name, bareDir, workspaceRoot, sourceWorktree string, releaseLock func(), fetchBase bool) error {
+func runAddFromBranch(branch string, switchTo, herdr bool, baseBranch, name, bareDir, workspaceRoot, sourceWorktree string, releaseLock func(), fetchBase bool) error {
 	dirName := name
 	if dirName == "" {
 		dirName = workspace.SanitizeBranchName(branch)
@@ -287,7 +294,7 @@ func runAddFromBranch(branch string, switchTo bool, baseBranch, name, bareDir, w
 		}
 	}
 
-	return finishWorktree(bareDir, sourceWorktree, worktreePath, branch, switchTo, releaseLock,
+	return finishWorktree(bareDir, sourceWorktree, worktreePath, branch, switchTo, herdr, releaseLock,
 		"Created worktree at %s", styles.RenderPath(worktreePath))
 }
 
@@ -335,7 +342,7 @@ func fastForwardIfBehind(bareDir, branch string, fetch bool) {
 	}
 }
 
-func runAddDetached(ref string, switchTo bool, name, bareDir, workspaceRoot, sourceWorktree string, releaseLock func()) error {
+func runAddDetached(ref string, switchTo, herdr bool, name, bareDir, workspaceRoot, sourceWorktree string, releaseLock func()) error {
 	dirName := name
 	if dirName == "" {
 		dirName = workspace.SanitizeBranchName(ref)
@@ -356,11 +363,11 @@ func runAddDetached(ref string, switchTo bool, name, bareDir, workspaceRoot, sou
 		return git.HintGitTooOld(fmt.Errorf("failed to create detached worktree: %w", err))
 	}
 
-	return finishWorktree(bareDir, sourceWorktree, worktreePath, "", switchTo, releaseLock,
+	return finishWorktree(bareDir, sourceWorktree, worktreePath, "", switchTo, herdr, releaseLock,
 		"Created detached worktree at %s", styles.RenderPath(worktreePath))
 }
 
-func runAddFromPR(prRef string, switchTo bool, name, bareDir, workspaceRoot, sourceWorktree string, reset bool, releaseLock func()) error {
+func runAddFromPR(prRef string, switchTo, herdr bool, name, bareDir, workspaceRoot, sourceWorktree string, reset bool, releaseLock func()) error {
 	// Check gh is available
 	if err := github.CheckGhAvailable(); err != nil {
 		return err
@@ -405,7 +412,7 @@ func runAddFromPR(prRef string, switchTo bool, name, bareDir, workspaceRoot, sou
 	}
 	for _, info := range infos {
 		if info.Branch == branch {
-			if !prInfo.IsFork {
+			if !prInfo.IsFork && !herdr {
 				if err := refreshExistingPRWorktree(bareDir, info.Path, branch, reset, switchTo); err != nil {
 					return err
 				}
@@ -428,7 +435,7 @@ func runAddFromPR(prRef string, switchTo bool, name, bareDir, workspaceRoot, sou
 		return err
 	}
 
-	return finishWorktree(bareDir, sourceWorktree, worktreePath, branch, switchTo, releaseLock,
+	return finishWorktree(bareDir, sourceWorktree, worktreePath, branch, switchTo, herdr, releaseLock,
 		"Created worktree for PR #%d at %s", ref.Number, styles.RenderPath(worktreePath))
 }
 
@@ -584,7 +591,7 @@ func checkoutPR(bareDir, worktreePath string, ref *github.PRRef, prInfo *github.
 	return nil
 }
 
-func finishWorktree(bareDir, sourceWorktree, worktreePath, branch string, switchTo bool, releaseLock func(), successFormat string, successArgs ...any) error {
+func finishWorktree(bareDir, sourceWorktree, worktreePath, branch string, switchTo, herdr bool, releaseLock func(), successFormat string, successArgs ...any) error {
 	if branch != "" {
 		workspace.AutoLockIfMatched(bareDir, worktreePath, branch)
 	}
@@ -597,6 +604,15 @@ func finishWorktree(bareDir, sourceWorktree, worktreePath, branch string, switch
 	spin.Stop()
 	if err := runAddHooks(sourceWorktree, worktreePath); err != nil {
 		return err
+	}
+
+	if herdr {
+		command := exec.Command("herdr", "worktree", "open", "--cwd", filepath.Dir(bareDir), "--path", worktreePath, "--focus") //nolint:gosec // Paths are passed as arguments, not shell commands.
+		command.Stderr = os.Stderr
+
+		if err := command.Run(); err != nil {
+			return fmt.Errorf("worktree prepared at %s, but Herdr could not open it (ensure herdr is installed and on PATH): %w", worktreePath, err)
+		}
 	}
 
 	if switchTo {

--- a/cmd/grove/commands/add.go
+++ b/cmd/grove/commands/add.go
@@ -20,6 +20,9 @@ import (
 	"github.com/sqve/grove/internal/workspace"
 )
 
+// ErrHerdrWorktreeExists means the requested PR branch already has a worktree.
+var ErrHerdrWorktreeExists = errors.New("worktree already exists")
+
 func NewAddCmd() *cobra.Command {
 	var baseBranch string
 	var name string
@@ -42,6 +45,7 @@ Examples:
   grove add feat/auth --name auth  # Creates ./auth worktree
   grove add main                   # Existing branch
   grove add -s feat/auth           # Add and switch to worktree
+  grove add feat/auth --herdr      # Open the prepared worktree in Herdr
   grove add --base main feat/auth  # New branch from main
   grove add --detach v1.0.0        # Detached HEAD at tag
   grove add --pr 123               # Creates ./pr-123 worktree
@@ -412,7 +416,11 @@ func runAddFromPR(prRef string, switchTo, herdr bool, name, bareDir, workspaceRo
 	}
 	for _, info := range infos {
 		if info.Branch == branch {
-			if !prInfo.IsFork && !herdr {
+			if herdr {
+				return fmt.Errorf("--herdr: %w for branch %q at %s; open that worktree directly in Herdr", ErrHerdrWorktreeExists, branch, info.Path)
+			}
+
+			if !prInfo.IsFork {
 				if err := refreshExistingPRWorktree(bareDir, info.Path, branch, reset, switchTo); err != nil {
 					return err
 				}
@@ -611,7 +619,16 @@ func finishWorktree(bareDir, sourceWorktree, worktreePath, branch string, switch
 		command.Stderr = os.Stderr
 
 		if err := command.Run(); err != nil {
-			return fmt.Errorf("worktree prepared at %s, but Herdr could not open it (ensure herdr is installed and on PATH): %w", worktreePath, err)
+			if errors.Is(err, exec.ErrNotFound) {
+				return fmt.Errorf("worktree prepared at %s, but Herdr could not open it (ensure herdr is installed and on PATH): %w", worktreePath, err)
+			}
+
+			var exitError *exec.ExitError
+			if errors.As(err, &exitError) {
+				return fmt.Errorf("worktree prepared at %s, but Herdr exited with an error; see its output above: %w", worktreePath, err)
+			}
+
+			return fmt.Errorf("worktree prepared at %s, but Herdr could not start: %w", worktreePath, err)
 		}
 	}
 

--- a/cmd/grove/commands/add_pr_test.go
+++ b/cmd/grove/commands/add_pr_test.go
@@ -50,12 +50,19 @@ printf '%s\n' '{"headRefName":"Feature/topic.v2","headRepository":{"name":"repo"
 		t.Fatalf("PR number = %q, want 42", configs["Feature/topic.v2"])
 	}
 
+	callPath := filepath.Join(t.TempDir(), "calls")
+	t.Setenv("HERDR_CALLS", callPath)
+	testutil.WriteFileMode(t, filepath.Join(filepath.Dir(ghPath), "herdr"), "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$HERDR_CALLS\"\n", fs.FileExec)
+
 	err = runAddFromPR("https://github.com/owner/repo/pull/42", false, true, "", bareDir, remote.TempDir, worktreePath, false, func() {})
-	if err == nil || !strings.Contains(err.Error(), "worktree already exists") {
-		t.Fatalf("expected --herdr to reject an existing PR worktree, got %v", err)
+	if err != nil {
+		t.Fatalf("handoff existing PR worktree: %v", err)
 	}
-	if !strings.Contains(err.Error(), worktreePath) || !strings.Contains(err.Error(), "open that worktree directly") || strings.Contains(err.Error(), "--name") {
-		t.Errorf("expected existing path and direct-open hint, got %v", err)
+
+	calls, err := os.ReadFile(callPath) //nolint:gosec // Test-owned temporary path.
+	want := "worktree\nopen\n--cwd\n" + remote.TempDir + "\n--path\n" + worktreePath + "\n--focus\n"
+	if err != nil || string(calls) != want {
+		t.Fatalf("calls = %q (%v), want %q", calls, err, want)
 	}
 	if _, err := os.Stat(filepath.Join(worktreePath, ".git")); err != nil {
 		t.Fatalf("existing worktree must remain intact: %v", err)

--- a/cmd/grove/commands/add_pr_test.go
+++ b/cmd/grove/commands/add_pr_test.go
@@ -37,7 +37,7 @@ printf '%s\n' '{"headRefName":"Feature/topic.v2","headRepository":{"name":"repo"
 
 	t.Setenv("PATH", filepath.Dir(ghPath)+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	err := runAddFromPR("https://github.com/owner/repo/pull/42", false, "", bareDir, remote.TempDir, worktreePath, false, func() {})
+	err := runAddFromPR("https://github.com/owner/repo/pull/42", false, false, "", bareDir, remote.TempDir, worktreePath, false, func() {})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,6 +48,11 @@ printf '%s\n' '{"headRefName":"Feature/topic.v2","headRepository":{"name":"repo"
 	}
 	if configs["Feature/topic.v2"] != "42" {
 		t.Fatalf("PR number = %q, want 42", configs["Feature/topic.v2"])
+	}
+
+	err = runAddFromPR("https://github.com/owner/repo/pull/42", false, true, "", bareDir, remote.TempDir, worktreePath, false, func() {})
+	if err == nil || !strings.Contains(err.Error(), "worktree already exists") {
+		t.Fatalf("expected --herdr to reject an existing PR worktree, got %v", err)
 	}
 }
 

--- a/cmd/grove/commands/add_pr_test.go
+++ b/cmd/grove/commands/add_pr_test.go
@@ -54,6 +54,12 @@ printf '%s\n' '{"headRefName":"Feature/topic.v2","headRepository":{"name":"repo"
 	if err == nil || !strings.Contains(err.Error(), "worktree already exists") {
 		t.Fatalf("expected --herdr to reject an existing PR worktree, got %v", err)
 	}
+	if !strings.Contains(err.Error(), worktreePath) || !strings.Contains(err.Error(), "open that worktree directly") || strings.Contains(err.Error(), "--name") {
+		t.Errorf("expected existing path and direct-open hint, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(worktreePath, ".git")); err != nil {
+		t.Fatalf("existing worktree must remain intact: %v", err)
+	}
 }
 
 func TestCheckoutPRRecordsNumber(t *testing.T) {

--- a/cmd/grove/commands/add_test.go
+++ b/cmd/grove/commands/add_test.go
@@ -72,6 +72,7 @@ func TestAddHerdr(t *testing.T) {
 			if !scenario.missing {
 				testutil.WriteFileMode(t, filepath.Join(binaryDir, "herdr"), `#!/bin/sh
 [ -f "$6/prepared" ] || exit 8
+[ -e "$4/.grove-worktree.lock" ] && exit 7
 printf '%s\n' "$@" >> "$HERDR_CALLS"
 printf 'herdr diagnostic\n' >&2
 exit "${HERDR_EXIT:-0}"

--- a/cmd/grove/commands/add_test.go
+++ b/cmd/grove/commands/add_test.go
@@ -268,6 +268,136 @@ printf '%s\n' "$@" >> "$HERDR_CALLS"
 	}
 }
 
+// testgit builds on testutil.TempDir, which resolves symlinks, so a symlinked
+// workspace root has to be built by hand to be exercised at all.
+func TestAddHerdrSymlinkedRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell herdr stub is not executable on Windows")
+	}
+
+	repository := testgit.NewTestRepo(t)
+	realRoot := filepath.Join(repository.TempDir, "real")
+	bareDir := filepath.Join(realRoot, ".bare")
+	repository.RunOutput("clone", "--bare", repository.Path, bareDir)
+	mainPath := filepath.Join(realRoot, "main")
+	repository.RunOutput("-C", bareDir, "worktree", "add", mainPath, "main")
+
+	linkRoot := filepath.Join(repository.TempDir, "link")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	// os.Getwd prefers $PWD when it names the same directory, which is how the
+	// unresolved spelling reaches Grove in a real shell.
+	linkMain := filepath.Join(linkRoot, "main")
+	t.Chdir(linkMain)
+	t.Setenv("PWD", linkMain)
+
+	binaryDir := t.TempDir()
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(gitPath, filepath.Join(binaryDir, "git")); err != nil {
+		t.Fatal(err)
+	}
+	callPath := filepath.Join(t.TempDir(), "calls")
+	t.Setenv("HERDR_CALLS", callPath)
+	testutil.WriteFileMode(t, filepath.Join(binaryDir, "herdr"), `#!/bin/sh
+printf '%s\n' "$@" >> "$HERDR_CALLS"
+`, fs.FileExec)
+	t.Setenv("PATH", binaryDir)
+
+	command := NewAddCmd()
+	command.SetArgs([]string{"main", "--detach", "--herdr", "--name", "probe", "--no-fetch"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+
+	command = NewAddCmd()
+	command.SetArgs([]string{"main", "--detach", "--herdr", "--name", "probe", "--no-fetch"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("rerun through the symlinked root must hand off, got: %v", err)
+	}
+
+	calls, err := os.ReadFile(callPath) //nolint:gosec // Test-owned temporary path.
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Both runs must send one identity, in the resolved namespace, or Herdr
+	// treats them as two workspaces.
+	want := "worktree\nopen\n--cwd\n" + realRoot + "\n--path\n" + filepath.Join(realRoot, "probe") + "\n--focus\n"
+	if string(calls) != want+want {
+		t.Fatalf("calls = %q, want two identical resolved calls %q", calls, want)
+	}
+}
+
+func TestAddHerdrOpensDirtyPRWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell herdr stub is not executable on Windows")
+	}
+
+	repository := testgit.NewTestRepo(t)
+	repository.CreateBranch("pr-feature")
+	workspaceRoot := filepath.Join(repository.TempDir, "workspace")
+	bareDir := filepath.Join(workspaceRoot, ".bare")
+	repository.RunOutput("clone", "--bare", repository.Path, bareDir)
+	mainPath := filepath.Join(workspaceRoot, "main")
+	repository.RunOutput("-C", bareDir, "worktree", "add", mainPath, "main")
+	t.Chdir(mainPath)
+
+	binaryDir := t.TempDir()
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(gitPath, filepath.Join(binaryDir, "git")); err != nil {
+		t.Fatal(err)
+	}
+	callPath := filepath.Join(t.TempDir(), "calls")
+	t.Setenv("HERDR_CALLS", callPath)
+	testutil.WriteFileMode(t, filepath.Join(binaryDir, "herdr"), `#!/bin/sh
+printf '%s\n' "$@" >> "$HERDR_CALLS"
+`, fs.FileExec)
+	testutil.WriteFileMode(t, filepath.Join(binaryDir, "gh"), `#!/bin/sh
+if [ "$1" = auth ]; then exit 0; fi
+printf '%s\n' '{"headRefName":"pr-feature","headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"owner"}}'
+`, fs.FileExec)
+	t.Setenv("PATH", binaryDir)
+
+	arguments := []string{"https://github.com/owner/repo/pull/42", "--herdr"}
+	command := NewAddCmd()
+	command.SetArgs(arguments)
+	if err := command.Execute(); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	worktreePath := filepath.Join(workspaceRoot, "pr-42")
+	if err := os.Remove(callPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// A worktree you are working in is dirty by definition; the refresh refuses
+	// it, and that must not also refuse to open it. test.txt is the tracked file
+	// NewTestRepo commits, so editing it is what trips the refusal.
+	testutil.WriteFile(t, filepath.Join(worktreePath, "test.txt"), "edited in the worktree")
+
+	command = NewAddCmd()
+	command.SetArgs(arguments)
+	if err := command.Execute(); err != nil {
+		t.Fatalf("dirty worktree must still open in Herdr, got: %v", err)
+	}
+
+	calls, err := os.ReadFile(callPath) //nolint:gosec // Test-owned temporary path.
+	if err != nil {
+		t.Fatalf("dirty worktree never reached Herdr: %v", err)
+	}
+	want := "worktree\nopen\n--cwd\n" + workspaceRoot + "\n--path\n" + worktreePath + "\n--focus\n"
+	if string(calls) != want {
+		t.Fatalf("calls = %q, want %q", calls, want)
+	}
+}
+
 func TestAddHerdrSwitchConflict(t *testing.T) {
 	command := NewAddCmd()
 	command.SetArgs([]string{"feature", "--herdr", "--switch"})

--- a/cmd/grove/commands/add_test.go
+++ b/cmd/grove/commands/add_test.go
@@ -182,6 +182,92 @@ printf '%s\n' '{"headRefName":"pr-feature","headRepository":{"name":"repo"},"hea
 	}
 }
 
+func TestAddHerdrDetachedRerun(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell herdr stub is not executable on Windows")
+	}
+
+	for _, scenario := range []struct {
+		name      string
+		ref       string
+		parkAtTag bool
+		wantCall  bool
+		wantError string
+	}{
+		{name: "annotated tag resolves to its commit", ref: "v1.0.0", wantCall: true},
+		{name: "refuses a worktree parked at another commit", ref: "main", parkAtTag: true, wantError: "not \"main\""},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			repository := testgit.NewTestRepo(t)
+			repository.RunOutput("-C", repository.Path, "tag", "-a", "v1.0.0", "-m", "release")
+			// Move main past the tag, so "main" and "v1.0.0" name different commits.
+			repository.WriteFile("moved", "after the tag")
+			repository.Add("moved")
+			repository.Commit("chore: move main past the tag")
+			workspaceRoot := filepath.Join(repository.TempDir, "workspace")
+			bareDir := filepath.Join(workspaceRoot, ".bare")
+			repository.RunOutput("clone", "--bare", repository.Path, bareDir)
+			repository.RunOutput("-C", bareDir, "fetch", "origin", "refs/tags/*:refs/tags/*")
+			mainPath := filepath.Join(workspaceRoot, "main")
+			repository.RunOutput("-C", bareDir, "worktree", "add", mainPath, "main")
+			t.Chdir(mainPath)
+
+			binaryDir := t.TempDir()
+			gitPath, err := exec.LookPath("git")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(gitPath, filepath.Join(binaryDir, "git")); err != nil {
+				t.Fatal(err)
+			}
+			callPath := filepath.Join(t.TempDir(), "calls")
+			t.Setenv("HERDR_CALLS", callPath)
+			testutil.WriteFileMode(t, filepath.Join(binaryDir, "herdr"), `#!/bin/sh
+printf '%s\n' "$@" >> "$HERDR_CALLS"
+`, fs.FileExec)
+			t.Setenv("PATH", binaryDir)
+
+			worktreePath := filepath.Join(workspaceRoot, "probe")
+			command := NewAddCmd()
+			command.SetArgs([]string{scenario.ref, "--detach", "--herdr", "--name", "probe", "--no-fetch"})
+			if err := command.Execute(); err != nil {
+				t.Fatalf("first run: %v", err)
+			}
+			if err := os.Remove(callPath); err != nil {
+				t.Fatal(err)
+			}
+
+			// Park the existing worktree on a commit the ref does not name.
+			if scenario.parkAtTag {
+				repository.RunOutput("-C", worktreePath, "checkout", "--detach", "v1.0.0")
+			}
+
+			command = NewAddCmd()
+			command.SetArgs([]string{scenario.ref, "--detach", "--herdr", "--name", "probe", "--no-fetch"})
+			err = command.Execute()
+
+			calls, readError := os.ReadFile(callPath) //nolint:gosec // Test-owned temporary path.
+			if scenario.wantCall {
+				if err != nil {
+					t.Fatalf("rerun must hand off: %v", err)
+				}
+				want := "worktree\nopen\n--cwd\n" + workspaceRoot + "\n--path\n" + worktreePath + "\n--focus\n"
+				if readError != nil || string(calls) != want {
+					t.Fatalf("calls = %q, error = %v, want %q", calls, readError, want)
+				}
+				return
+			}
+
+			if err == nil || !strings.Contains(err.Error(), scenario.wantError) {
+				t.Fatalf("error = %v, want %q", err, scenario.wantError)
+			}
+			if !os.IsNotExist(readError) {
+				t.Fatalf("mismatched HEAD must not reach Herdr: %q", calls)
+			}
+		})
+	}
+}
+
 func TestAddHerdrSwitchConflict(t *testing.T) {
 	command := NewAddCmd()
 	command.SetArgs([]string{"feature", "--herdr", "--switch"})

--- a/cmd/grove/commands/add_test.go
+++ b/cmd/grove/commands/add_test.go
@@ -110,6 +110,21 @@ printf '%s\n' '{"headRefName":"pr-feature","headRepository":{"name":"repo"},"hea
 					t.Fatalf("expected wrapped error naming prepared path, got %v", err)
 				}
 			}
+			if scenario.missing {
+				if !errors.Is(err, exec.ErrNotFound) || !strings.Contains(err.Error(), "ensure herdr is installed and on PATH") {
+					t.Fatalf("expected missing binary with install hint, got %v", err)
+				}
+			}
+			if scenario.exitCode != "" {
+				var exitError *exec.ExitError
+				if !errors.As(err, &exitError) || !strings.Contains(err.Error(), "Herdr exited with an error") || !strings.Contains(err.Error(), "output above") {
+					t.Errorf("expected failed exit with output hint, got %v", err)
+				}
+				if strings.Contains(err.Error(), "installed") || strings.Contains(err.Error(), "PATH") {
+					t.Errorf("unexpected install hint after Herdr ran: %v", err)
+				}
+			}
+
 			if _, err := os.Stat(filepath.Join(worktreePath, ".git")); err != nil {
 				t.Fatalf("worktree must remain intact: %v", err)
 			}

--- a/cmd/grove/commands/add_test.go
+++ b/cmd/grove/commands/add_test.go
@@ -142,6 +142,41 @@ printf '%s\n' '{"headRefName":"pr-feature","headRepository":{"name":"repo"},"hea
 			} else if !os.IsNotExist(readError) {
 				t.Fatalf("unexpected herdr call: %q (%v)", calls, readError)
 			}
+
+			if scenario.wantCall && scenario.wantError == "" {
+				worktreesBefore := repository.RunOutput("-C", bareDir, "worktree", "list", "--porcelain")
+				branchesBefore := repository.RunOutput("-C", bareDir, "show-ref", "--heads")
+				testutil.WriteFile(t, filepath.Join(mainPath, "preserved"), "new source file")
+				testutil.WriteFile(t, filepath.Join(mainPath, "linked", "file"), "new source directory")
+				testutil.WriteFile(t, filepath.Join(mainPath, ".grove.toml"), "[preserve]\npatterns = [\"preserved\"]\n[link]\npatterns = [\"linked\"]\n[hooks]\nadd = [\"exit 9\"]\n")
+
+				rerunName := "unused directory"
+				if scenario.name == "detached" {
+					rerunName = "prepared tree"
+				}
+				command = NewAddCmd()
+				command.SetArgs(append(scenario.arguments, "--name", rerunName, "--no-fetch"))
+				if err := command.Execute(); err != nil {
+					t.Fatalf("handoff-only rerun: %v", err)
+				}
+
+				rerunCalls, err := os.ReadFile(callPath) //nolint:gosec // Test-owned temporary path.
+				if err != nil || string(rerunCalls) != string(calls)+string(calls) {
+					t.Fatalf("rerun must use identical argv: %q (%v)", rerunCalls, err)
+				}
+				worktreesAfter := repository.RunOutput("-C", bareDir, "worktree", "list", "--porcelain")
+				if worktreesAfter != worktreesBefore || strings.Count(worktreesAfter, "worktree "+worktreePath+"\n") != 1 {
+					t.Fatalf("rerun changed worktrees: %s", worktreesAfter)
+				}
+				if branchesAfter := repository.RunOutput("-C", bareDir, "show-ref", "--heads"); branchesAfter != branchesBefore {
+					t.Fatalf("rerun changed branches: %s", branchesAfter)
+				}
+				for _, absentPath := range []string{filepath.Join(workspaceRoot, "unused directory"), filepath.Join(worktreePath, "preserved"), filepath.Join(worktreePath, "linked"), filepath.Join(workspaceRoot, ".grove-worktree.lock")} {
+					if _, err := os.Lstat(absentPath); !os.IsNotExist(err) {
+						t.Fatalf("handoff-only rerun created %s (%v)", absentPath, err)
+					}
+				}
+			}
 		})
 	}
 }

--- a/cmd/grove/commands/add_test.go
+++ b/cmd/grove/commands/add_test.go
@@ -5,14 +5,141 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/sqve/grove/internal/fs"
 	"github.com/sqve/grove/internal/testutil"
+	testgit "github.com/sqve/grove/internal/testutil/git"
 	"github.com/sqve/grove/internal/workspace"
 )
+
+func TestAddHerdr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell herdr stub is not executable on Windows")
+	}
+
+	for _, scenario := range []struct {
+		name      string
+		arguments []string
+		hook      string
+		exitCode  string
+		missing   bool
+		wantCall  bool
+		wantError string
+	}{
+		{name: "branch", arguments: []string{"feature", "--herdr"}, wantCall: true},
+		{name: "detached", arguments: []string{"main", "--detach", "--herdr"}, wantCall: true},
+		{name: "pull request", arguments: []string{"https://github.com/owner/repo/pull/42", "--herdr"}, wantCall: true},
+		{name: "without flag", arguments: []string{"feature"}},
+		{name: "failed hook", arguments: []string{"feature", "--herdr"}, hook: "exit 9", wantError: "hook failed"},
+		{name: "missing binary", arguments: []string{"feature", "--herdr"}, missing: true, wantError: "PATH"},
+		{name: "failed handoff", arguments: []string{"feature", "--herdr"}, exitCode: "7", wantCall: true, wantError: "exit status 7"},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			repository := testgit.NewTestRepo(t)
+			repository.CreateBranch("pr-feature")
+			workspaceRoot := filepath.Join(repository.TempDir, "workspace with spaces")
+			bareDir := filepath.Join(workspaceRoot, ".bare")
+			repository.RunOutput("clone", "--bare", repository.Path, bareDir)
+			mainPath := filepath.Join(workspaceRoot, "main")
+			repository.RunOutput("-C", bareDir, "worktree", "add", mainPath, "main")
+			t.Chdir(mainPath)
+
+			hook := "printf ready > prepared"
+			if scenario.hook != "" {
+				hook = scenario.hook
+			}
+			testutil.WriteFile(t, filepath.Join(mainPath, ".grove.toml"), "[hooks]\nadd = [\""+hook+"\"]\n")
+
+			binaryDir := t.TempDir()
+			gitPath, err := exec.LookPath("git")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(gitPath, filepath.Join(binaryDir, "git")); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink("/bin/sh", filepath.Join(binaryDir, "sh")); err != nil {
+				t.Fatal(err)
+			}
+
+			callPath := filepath.Join(t.TempDir(), "calls")
+			t.Setenv("HERDR_CALLS", callPath)
+			t.Setenv("HERDR_EXIT", scenario.exitCode)
+			if !scenario.missing {
+				testutil.WriteFileMode(t, filepath.Join(binaryDir, "herdr"), `#!/bin/sh
+[ -f "$6/prepared" ] || exit 8
+printf '%s\n' "$@" >> "$HERDR_CALLS"
+printf 'herdr diagnostic\n' >&2
+exit "${HERDR_EXIT:-0}"
+`, fs.FileExec)
+			}
+			testutil.WriteFileMode(t, filepath.Join(binaryDir, "gh"), `#!/bin/sh
+if [ "$1" = auth ]; then exit 0; fi
+printf '%s\n' '{"headRefName":"pr-feature","headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"owner"}}'
+`, fs.FileExec)
+			t.Setenv("PATH", binaryDir)
+
+			stderr, err := os.CreateTemp(t.TempDir(), "stderr")
+			if err != nil {
+				t.Fatal(err)
+			}
+			originalStderr := os.Stderr
+			os.Stderr = stderr
+			t.Cleanup(func() {
+				os.Stderr = originalStderr
+				_ = stderr.Close()
+			})
+
+			command := NewAddCmd()
+			command.SetArgs(append(scenario.arguments, "--name", "prepared tree", "--no-fetch"))
+			err = command.Execute()
+			worktreePath := filepath.Join(workspaceRoot, "prepared tree")
+			if scenario.wantError == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), scenario.wantError) {
+				t.Fatalf("error = %v, want %q", err, scenario.wantError)
+			}
+			if scenario.missing || scenario.exitCode != "" {
+				if !strings.Contains(err.Error(), worktreePath) || errors.Unwrap(err) == nil {
+					t.Fatalf("expected wrapped error naming prepared path, got %v", err)
+				}
+			}
+			if _, err := os.Stat(filepath.Join(worktreePath, ".git")); err != nil {
+				t.Fatalf("worktree must remain intact: %v", err)
+			}
+
+			calls, readError := os.ReadFile(callPath) //nolint:gosec // Test-owned temporary path.
+			if scenario.wantCall {
+				want := "worktree\nopen\n--cwd\n" + workspaceRoot + "\n--path\n" + worktreePath + "\n--focus\n"
+				if readError != nil || string(calls) != want {
+					t.Fatalf("calls = %q, error = %v, want %q", calls, readError, want)
+				}
+				diagnostic, err := os.ReadFile(stderr.Name())
+				if err != nil || !strings.Contains(string(diagnostic), "herdr diagnostic") {
+					t.Fatalf("missing inherited stderr: %q (%v)", diagnostic, err)
+				}
+			} else if !os.IsNotExist(readError) {
+				t.Fatalf("unexpected herdr call: %q (%v)", calls, readError)
+			}
+		})
+	}
+}
+
+func TestAddHerdrSwitchConflict(t *testing.T) {
+	command := NewAddCmd()
+	command.SetArgs([]string{"feature", "--herdr", "--switch"})
+
+	err := command.Execute()
+	if err == nil || !strings.Contains(err.Error(), "herdr") || !strings.Contains(err.Error(), "switch") {
+		t.Fatalf("expected flag conflict, got %v", err)
+	}
+}
 
 func TestNewAddCmd(t *testing.T) {
 	cmd := NewAddCmd()
@@ -33,6 +160,7 @@ func TestNewAddCmd(t *testing.T) {
 		valueType string
 	}{
 		{"switch", "s", "false", "bool"},
+		{"herdr", "", "false", "bool"},
 		{"base", "", "", "string"},
 		{"detach", "d", "false", "bool"},
 		{"name", "", "", "string"},
@@ -75,7 +203,7 @@ func TestRunAdd_NotInWorkspace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = runAdd([]string{"feature-test"}, false, "", "", false, 0, false, "", false)
+	err = runAdd([]string{"feature-test"}, false, false, "", "", false, 0, false, "", false)
 	if !errors.Is(err, workspace.ErrNotInWorkspace) {
 		t.Errorf("expected ErrNotInWorkspace, got %v", err)
 	}
@@ -94,56 +222,56 @@ func TestRunAdd_PRValidation(t *testing.T) {
 	}
 
 	t.Run("base flag cannot be used with --pr", func(t *testing.T) {
-		err := runAdd(nil, false, "main", "", false, 123, false, "", false)
+		err := runAdd(nil, false, false, "main", "", false, 123, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--base cannot be used with PR") {
 			t.Errorf("expected base/PR error, got %v", err)
 		}
 	})
 
 	t.Run("detach flag cannot be used with --pr", func(t *testing.T) {
-		err := runAdd(nil, false, "", "", true, 123, false, "", false)
+		err := runAdd(nil, false, false, "", "", true, 123, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--detach cannot be used with PR") {
 			t.Errorf("expected detach/PR error, got %v", err)
 		}
 	})
 
 	t.Run("negative --pr gives clear error", func(t *testing.T) {
-		err := runAdd(nil, false, "", "", false, -5, false, "", false)
+		err := runAdd(nil, false, false, "", "", false, -5, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--pr must be a positive number") {
 			t.Errorf("expected positive number error, got %v", err)
 		}
 	})
 
 	t.Run("--pr cannot be combined with positional argument", func(t *testing.T) {
-		err := runAdd([]string{"feature"}, false, "", "", false, 123, false, "", false)
+		err := runAdd([]string{"feature"}, false, false, "", "", false, 123, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--pr flag cannot be combined with positional argument") {
 			t.Errorf("expected --pr/positional conflict error, got %v", err)
 		}
 	})
 
 	t.Run("old #N syntax gives helpful error", func(t *testing.T) {
-		err := runAdd([]string{"#123"}, false, "", "", false, 0, false, "", false)
+		err := runAdd([]string{"#123"}, false, false, "", "", false, 0, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "syntax no longer supported") {
 			t.Errorf("expected helpful migration error, got %v", err)
 		}
 	})
 
 	t.Run("base flag cannot be used with PR URL", func(t *testing.T) {
-		err := runAdd([]string{"https://github.com/owner/repo/pull/456"}, false, "main", "", false, 0, false, "", false)
+		err := runAdd([]string{"https://github.com/owner/repo/pull/456"}, false, false, "main", "", false, 0, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--base cannot be used with PR") {
 			t.Errorf("expected base/PR error, got %v", err)
 		}
 	})
 
 	t.Run("detach flag cannot be used with PR URL", func(t *testing.T) {
-		err := runAdd([]string{"https://github.com/owner/repo/pull/456"}, false, "", "", true, 0, false, "", false)
+		err := runAdd([]string{"https://github.com/owner/repo/pull/456"}, false, false, "", "", true, 0, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--detach cannot be used with PR") {
 			t.Errorf("expected detach/PR error, got %v", err)
 		}
 	})
 
 	t.Run("reset flag can only be used with PR references", func(t *testing.T) {
-		err := runAdd([]string{"feature-branch"}, false, "", "", false, 0, true, "", false)
+		err := runAdd([]string{"feature-branch"}, false, false, "", "", false, 0, true, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--reset can only be used with PR references") {
 			t.Errorf("expected --reset/PR error, got %v", err)
 		}
@@ -152,7 +280,7 @@ func TestRunAdd_PRValidation(t *testing.T) {
 
 func TestRunAdd_DetachBaseValidation(t *testing.T) {
 	t.Run("detach and base cannot be used together", func(t *testing.T) {
-		err := runAdd([]string{"v1.0.0"}, false, "main", "", true, 0, false, "", false)
+		err := runAdd([]string{"v1.0.0"}, false, false, "main", "", true, 0, false, "", false)
 		if err == nil || err.Error() != "--detach and --base cannot be used together" {
 			t.Errorf("expected detach/base error, got %v", err)
 		}
@@ -175,14 +303,14 @@ func TestRunAdd_InputValidation(t *testing.T) {
 	t.Run("whitespace-only branch name", func(t *testing.T) {
 		// Whitespace is trimmed, resulting in empty string
 		// This should fail with "requires branch" error
-		err := runAdd([]string{"   "}, false, "", "", false, 0, false, "", false)
+		err := runAdd([]string{"   "}, false, false, "", "", false, 0, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "requires branch") {
 			t.Errorf("expected 'requires branch' error for whitespace-only branch name, got %v", err)
 		}
 	})
 
 	t.Run("no args and no --pr flag", func(t *testing.T) {
-		err := runAdd(nil, false, "", "", false, 0, false, "", false)
+		err := runAdd(nil, false, false, "", "", false, 0, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "requires branch") {
 			t.Errorf("expected 'requires branch' error, got %v", err)
 		}
@@ -192,7 +320,7 @@ func TestRunAdd_InputValidation(t *testing.T) {
 		// The trimming happens, then workspace detection runs
 		// We're not in a workspace, so we'll get that error
 		// But this verifies the trim doesn't crash
-		err := runAdd([]string{"  feature-test  "}, false, "", "", false, 0, false, "", false)
+		err := runAdd([]string{"  feature-test  "}, false, false, "", "", false, 0, false, "", false)
 		if !errors.Is(err, workspace.ErrNotInWorkspace) {
 			t.Errorf("expected ErrNotInWorkspace after trimming, got %v", err)
 		}
@@ -201,14 +329,14 @@ func TestRunAdd_InputValidation(t *testing.T) {
 	t.Run("PR URL with /files suffix works", func(t *testing.T) {
 		// PR URLs with /files suffix should be detected as PR references
 		// Flag validation happens before workspace detection
-		err := runAdd([]string{"https://github.com/owner/repo/pull/123/files"}, false, "main", "", false, 0, false, "", false)
+		err := runAdd([]string{"https://github.com/owner/repo/pull/123/files"}, false, false, "main", "", false, 0, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--base cannot be used with PR") {
 			t.Errorf("expected base/PR error for URL with /files suffix, got %v", err)
 		}
 	})
 
 	t.Run("PR URL with query params works", func(t *testing.T) {
-		err := runAdd([]string{"https://github.com/owner/repo/pull/123?diff=split"}, false, "", "", true, 0, false, "", false)
+		err := runAdd([]string{"https://github.com/owner/repo/pull/123?diff=split"}, false, false, "", "", true, 0, false, "", false)
 		if err == nil || !strings.Contains(err.Error(), "--detach cannot be used with PR") {
 			t.Errorf("expected detach/PR error for URL with query params, got %v", err)
 		}
@@ -820,7 +948,7 @@ func TestRunAdd_FromValidation(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err := runAdd([]string{"feature-test"}, false, "", "", false, 0, false, "nonexistent", false)
+		err := runAdd([]string{"feature-test"}, false, false, "", "", false, 0, false, "nonexistent", false)
 		if err == nil {
 			t.Fatal("expected error for nonexistent --from worktree")
 		}
@@ -857,7 +985,7 @@ func TestRunAdd_FromValidation(t *testing.T) {
 		})
 
 		// Create a new worktree with --from pointing to source
-		err := runAdd([]string{"feature-from-test"}, false, "", "", false, 0, false, "source", false)
+		err := runAdd([]string{"feature-from-test"}, false, false, "", "", false, 0, false, "source", false)
 		if err != nil {
 			t.Errorf("expected success with valid --from, got %v", err)
 		}
@@ -938,7 +1066,7 @@ func TestRunAddFromBranch_WorktreeExistsHint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = runAdd([]string{"main"}, false, "", "", false, 0, false, "", false)
+	err = runAdd([]string{"main"}, false, false, "", "", false, 0, false, "", false)
 	if err == nil {
 		t.Fatal("expected error for existing worktree")
 	}
@@ -1014,7 +1142,7 @@ func TestRunAdd_LinkPatternsAppliedFromOutsideWorktree(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runAdd([]string{"feat"}, false, "", "", false, 0, false, "", false); err != nil {
+	if err := runAdd([]string{"feat"}, false, false, "", "", false, 0, false, "", false); err != nil {
 		t.Fatalf("runAdd: %v", err)
 	}
 
@@ -1096,7 +1224,7 @@ func TestRunAdd_LinkAppliedWhenOnlyNonMainWorktreeHasConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runAdd([]string{"newwork"}, false, "", "", false, 0, false, "", false); err != nil {
+	if err := runAdd([]string{"newwork"}, false, false, "", "", false, 0, false, "", false); err != nil {
 		t.Fatalf("runAdd: %v", err)
 	}
 

--- a/cmd/grove/commands/add_test.go
+++ b/cmd/grove/commands/add_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/sqve/grove/internal/fs"
+	"github.com/sqve/grove/internal/git"
 	"github.com/sqve/grove/internal/testutil"
 	testgit "github.com/sqve/grove/internal/testutil/git"
 	"github.com/sqve/grove/internal/workspace"
@@ -382,6 +383,17 @@ printf '%s\n' '{"headRefName":"pr-feature","headRepository":{"name":"repo"},"hea
 	// NewTestRepo commits, so editing it is what trips the refusal.
 	testutil.WriteFile(t, filepath.Join(worktreePath, "test.txt"), "edited in the worktree")
 
+	stderr, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalStderr := os.Stderr
+	os.Stderr = stderr
+	t.Cleanup(func() {
+		os.Stderr = originalStderr
+		_ = stderr.Close()
+	})
+
 	command = NewAddCmd()
 	command.SetArgs(arguments)
 	if err := command.Execute(); err != nil {
@@ -395,6 +407,138 @@ printf '%s\n' '{"headRefName":"pr-feature","headRepository":{"name":"repo"},"hea
 	want := "worktree\nopen\n--cwd\n" + workspaceRoot + "\n--path\n" + worktreePath + "\n--focus\n"
 	if string(calls) != want {
 		t.Fatalf("calls = %q, want %q", calls, want)
+	}
+
+	// The handoff must open the work in progress, never discard it.
+	edited, err := os.ReadFile(filepath.Join(worktreePath, "test.txt")) //nolint:gosec // Test-owned temporary path.
+	if err != nil || string(edited) != "edited in the worktree" {
+		t.Fatalf("handoff destroyed the uncommitted edit: %q (%v)", edited, err)
+	}
+
+	// Pin the reason, so a fetch failure taking the same path is not mistaken
+	// for the dirty-worktree branch this test is named for.
+	warning, err := os.ReadFile(stderr.Name()) //nolint:gosec // Test-owned temporary path.
+	if err != nil || !strings.Contains(string(warning), "uncommitted changes") {
+		t.Fatalf("expected the uncommitted-changes warning, got %q (%v)", warning, err)
+	}
+}
+
+// The PR number is recorded even when the sync that follows refuses, or a
+// worktree adopted by a PR re-run never shows its PR in grove list.
+func TestAddHerdrRecordsPROnDirtyWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell herdr stub is not executable on Windows")
+	}
+
+	repository := testgit.NewTestRepo(t)
+	repository.CreateBranch("pr-feature")
+	workspaceRoot := filepath.Join(repository.TempDir, "workspace")
+	bareDir := filepath.Join(workspaceRoot, ".bare")
+	repository.RunOutput("clone", "--bare", repository.Path, bareDir)
+	mainPath := filepath.Join(workspaceRoot, "main")
+	repository.RunOutput("-C", bareDir, "worktree", "add", mainPath, "main")
+	t.Chdir(mainPath)
+
+	binaryDir := t.TempDir()
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(gitPath, filepath.Join(binaryDir, "git")); err != nil {
+		t.Fatal(err)
+	}
+	callPath := filepath.Join(t.TempDir(), "calls")
+	t.Setenv("HERDR_CALLS", callPath)
+	testutil.WriteFileMode(t, filepath.Join(binaryDir, "herdr"), `#!/bin/sh
+printf '%s\n' "$@" >> "$HERDR_CALLS"
+`, fs.FileExec)
+	testutil.WriteFileMode(t, filepath.Join(binaryDir, "gh"), `#!/bin/sh
+if [ "$1" = auth ]; then exit 0; fi
+printf '%s\n' '{"headRefName":"pr-feature","headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"owner"}}'
+`, fs.FileExec)
+	t.Setenv("PATH", binaryDir)
+
+	// Created as a plain branch worktree, so nothing has recorded a PR yet.
+	command := NewAddCmd()
+	command.SetArgs([]string{"pr-feature", "--no-fetch"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("branch add: %v", err)
+	}
+	worktreePath := filepath.Join(workspaceRoot, "pr-feature")
+	testutil.WriteFile(t, filepath.Join(worktreePath, "test.txt"), "edited in the worktree")
+
+	command = NewAddCmd()
+	command.SetArgs([]string{"https://github.com/owner/repo/pull/42", "--herdr"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("dirty PR re-run must open, got: %v", err)
+	}
+
+	configs, err := git.GetBranchConfigs(bareDir, "grovePr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if configs["pr-feature"] != "42" {
+		t.Fatalf("grovePr = %q, want \"42\"", configs["pr-feature"])
+	}
+}
+
+// A refresh that fails for any reason other than work in progress must abort:
+// the worktree may be half-synced, and opening it would hide that.
+func TestAddHerdrAbortsOnBrokenPRRefresh(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell herdr stub is not executable on Windows")
+	}
+
+	repository := testgit.NewTestRepo(t)
+	repository.CreateBranch("pr-feature")
+	workspaceRoot := filepath.Join(repository.TempDir, "workspace")
+	bareDir := filepath.Join(workspaceRoot, ".bare")
+	repository.RunOutput("clone", "--bare", repository.Path, bareDir)
+	mainPath := filepath.Join(workspaceRoot, "main")
+	repository.RunOutput("-C", bareDir, "worktree", "add", mainPath, "main")
+	t.Chdir(mainPath)
+
+	binaryDir := t.TempDir()
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(gitPath, filepath.Join(binaryDir, "git")); err != nil {
+		t.Fatal(err)
+	}
+	callPath := filepath.Join(t.TempDir(), "calls")
+	t.Setenv("HERDR_CALLS", callPath)
+	testutil.WriteFileMode(t, filepath.Join(binaryDir, "herdr"), `#!/bin/sh
+printf '%s\n' "$@" >> "$HERDR_CALLS"
+`, fs.FileExec)
+	testutil.WriteFileMode(t, filepath.Join(binaryDir, "gh"), `#!/bin/sh
+if [ "$1" = auth ]; then exit 0; fi
+printf '%s\n' '{"headRefName":"pr-feature","headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"owner"}}'
+`, fs.FileExec)
+	t.Setenv("PATH", binaryDir)
+
+	arguments := []string{"https://github.com/owner/repo/pull/42", "--herdr"}
+	command := NewAddCmd()
+	command.SetArgs(arguments)
+	if err := command.Execute(); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if err := os.Remove(callPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Break the fetch the refresh depends on, leaving the worktree clean.
+	repository.RunOutput("-C", bareDir, "remote", "set-url", "origin", filepath.Join(repository.TempDir, "gone"))
+
+	command = NewAddCmd()
+	command.SetArgs(arguments)
+	err = command.Execute()
+
+	if err == nil || !strings.Contains(err.Error(), "fetch") {
+		t.Fatalf("a broken fetch must abort, got %v", err)
+	}
+	if calls, readError := os.ReadFile(callPath); !os.IsNotExist(readError) { //nolint:gosec // Test-owned temporary path.
+		t.Fatalf("a broken refresh must not reach Herdr: %q", calls)
 	}
 }
 

--- a/cmd/grove/commands/add_test.go
+++ b/cmd/grove/commands/add_test.go
@@ -482,6 +482,83 @@ printf '%s\n' '{"headRefName":"pr-feature","headRepository":{"name":"repo"},"hea
 	}
 }
 
+// A fork PR worktree is checked out from the fork's remote-tracking ref, so it
+// is detached and has no branch to match on. Its path is the identity.
+func TestAddHerdrRerunsForkPRWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell herdr stub is not executable on Windows")
+	}
+
+	repository := testgit.NewTestRepo(t)
+	repository.CreateBranch("fork-feature")
+	workspaceRoot := filepath.Join(repository.TempDir, "workspace")
+	bareDir := filepath.Join(workspaceRoot, ".bare")
+	repository.RunOutput("clone", "--bare", repository.Path, bareDir)
+	mainPath := filepath.Join(workspaceRoot, "main")
+	repository.RunOutput("-C", bareDir, "worktree", "add", mainPath, "main")
+	t.Chdir(mainPath)
+
+	binaryDir := t.TempDir()
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(gitPath, filepath.Join(binaryDir, "git")); err != nil {
+		t.Fatal(err)
+	}
+	callPath := filepath.Join(t.TempDir(), "calls")
+	t.Setenv("HERDR_CALLS", callPath)
+	testutil.WriteFileMode(t, filepath.Join(binaryDir, "herdr"), `#!/bin/sh
+printf '%s\n' "$@" >> "$HERDR_CALLS"
+`, fs.FileExec)
+	// headRepositoryOwner differs from the URL's owner, which is what makes it a
+	// fork; repo view hands back the local repo standing in for the fork.
+	testutil.WriteFileMode(t, filepath.Join(binaryDir, "gh"), `#!/bin/sh
+if [ "$1" = auth ]; then exit 0; fi
+if [ "$1" = repo ]; then printf '%s\n' "$GH_FORK_URL"; exit 0; fi
+printf '%s\n' '{"headRefName":"fork-feature","headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"contributor"}}'
+`, fs.FileExec)
+	t.Setenv("GH_FORK_URL", repository.Path)
+	t.Setenv("PATH", binaryDir)
+
+	arguments := []string{"https://github.com/owner/repo/pull/42", "--herdr"}
+	command := NewAddCmd()
+	command.SetArgs(arguments)
+	if err := command.Execute(); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	worktreePath := filepath.Join(workspaceRoot, "pr-42")
+
+	// The fork worktree must be detached, or this test is not exercising the bug.
+	listing := repository.RunOutput("-C", bareDir, "worktree", "list", "--porcelain")
+	if !strings.Contains(listing, "worktree "+worktreePath+"\nHEAD") || !strings.Contains(listing, "detached") {
+		t.Fatalf("expected a detached fork worktree, got %s", listing)
+	}
+	if err := os.Remove(callPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// A local worktree that merely shares the fork's branch name must not be
+	// mistaken for the PR's worktree.
+	decoyPath := filepath.Join(workspaceRoot, "decoy")
+	repository.RunOutput("-C", bareDir, "worktree", "add", decoyPath, "fork-feature")
+
+	command = NewAddCmd()
+	command.SetArgs(arguments)
+	if err := command.Execute(); err != nil {
+		t.Fatalf("fork PR rerun must hand off, got: %v", err)
+	}
+
+	calls, err := os.ReadFile(callPath) //nolint:gosec // Test-owned temporary path.
+	if err != nil {
+		t.Fatalf("fork PR rerun never reached Herdr: %v", err)
+	}
+	want := "worktree\nopen\n--cwd\n" + workspaceRoot + "\n--path\n" + worktreePath + "\n--focus\n"
+	if string(calls) != want {
+		t.Fatalf("calls = %q, want the fork PR worktree %q", calls, want)
+	}
+}
+
 // Local commits are work in progress too, so --herdr opens past that refusal
 // exactly as it does past a dirty worktree.
 func TestAddHerdrOpensUnsyncedPRWorktree(t *testing.T) {

--- a/cmd/grove/commands/add_test.go
+++ b/cmd/grove/commands/add_test.go
@@ -482,6 +482,95 @@ printf '%s\n' '{"headRefName":"pr-feature","headRepository":{"name":"repo"},"hea
 	}
 }
 
+// Local commits are work in progress too, so --herdr opens past that refusal
+// exactly as it does past a dirty worktree.
+func TestAddHerdrOpensUnsyncedPRWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell herdr stub is not executable on Windows")
+	}
+
+	repository := testgit.NewTestRepo(t)
+	repository.CreateBranch("pr-feature")
+	workspaceRoot := filepath.Join(repository.TempDir, "workspace")
+	bareDir := filepath.Join(workspaceRoot, ".bare")
+	repository.RunOutput("clone", "--bare", repository.Path, bareDir)
+	mainPath := filepath.Join(workspaceRoot, "main")
+	repository.RunOutput("-C", bareDir, "worktree", "add", mainPath, "main")
+	t.Chdir(mainPath)
+
+	binaryDir := t.TempDir()
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(gitPath, filepath.Join(binaryDir, "git")); err != nil {
+		t.Fatal(err)
+	}
+	callPath := filepath.Join(t.TempDir(), "calls")
+	t.Setenv("HERDR_CALLS", callPath)
+	testutil.WriteFileMode(t, filepath.Join(binaryDir, "herdr"), `#!/bin/sh
+printf '%s\n' "$@" >> "$HERDR_CALLS"
+`, fs.FileExec)
+	testutil.WriteFileMode(t, filepath.Join(binaryDir, "gh"), `#!/bin/sh
+if [ "$1" = auth ]; then exit 0; fi
+printf '%s\n' '{"headRefName":"pr-feature","headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"owner"}}'
+`, fs.FileExec)
+	t.Setenv("PATH", binaryDir)
+
+	arguments := []string{"https://github.com/owner/repo/pull/42", "--herdr"}
+	command := NewAddCmd()
+	command.SetArgs(arguments)
+	if err := command.Execute(); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	worktreePath := filepath.Join(workspaceRoot, "pr-42")
+	if err := os.Remove(callPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Commit locally so the branch is ahead of the PR head, leaving the worktree
+	// clean: this is the other refusal, not the dirty one.
+	repository.RunOutput("-C", worktreePath, "-c", "commit.gpgsign=false",
+		"-c", "user.email=test@example.com", "-c", "user.name=Test",
+		"commit", "--allow-empty", "-m", "local work not yet pushed")
+
+	stderr, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalStderr := os.Stderr
+	os.Stderr = stderr
+	t.Cleanup(func() {
+		os.Stderr = originalStderr
+		_ = stderr.Close()
+	})
+
+	command = NewAddCmd()
+	command.SetArgs(arguments)
+	if err := command.Execute(); err != nil {
+		t.Fatalf("unsynced worktree must still open in Herdr, got: %v", err)
+	}
+
+	calls, err := os.ReadFile(callPath) //nolint:gosec // Test-owned temporary path.
+	if err != nil {
+		t.Fatalf("unsynced worktree never reached Herdr: %v", err)
+	}
+	want := "worktree\nopen\n--cwd\n" + workspaceRoot + "\n--path\n" + worktreePath + "\n--focus\n"
+	if string(calls) != want {
+		t.Fatalf("calls = %q, want %q", calls, want)
+	}
+
+	// Without --reset the local commits must survive being opened.
+	if subject := repository.RunOutput("-C", worktreePath, "log", "-1", "--format=%s"); !strings.Contains(subject, "local work not yet pushed") {
+		t.Fatalf("handoff discarded the local commit, HEAD is now %q", subject)
+	}
+
+	warning, err := os.ReadFile(stderr.Name()) //nolint:gosec // Test-owned temporary path.
+	if err != nil || !strings.Contains(string(warning), "not on remote") {
+		t.Fatalf("expected the local-commits warning, got %q (%v)", warning, err)
+	}
+}
+
 // A refresh that fails for any reason other than work in progress must abort:
 // the worktree may be half-synced, and opening it would hide that.
 func TestAddHerdrAbortsOnBrokenPRRefresh(t *testing.T) {


### PR DESCRIPTION
**`grove add --herdr` hands the finished worktree to the Herdr CLI, so preparing a worktree and opening it are one command.**

Opening a new worktree in Herdr was a manual second step: run `grove add`, then open the worktree yourself. The flag is opt-in and fire-and-forget — Grove spawns `herdr worktree open` once everything else has succeeded, and stores nothing. Herdr owns workspace identity, keyed on the canonical checkout path, so a re-run focuses the workspace that already exists instead of erroring.

#### Changes

- `grove add --herdr` runs `herdr worktree open --cwd <workspace root> --path <worktree> --focus` after checkout, file preservation, linking and add hooks all succeed. `--cwd` is the parent of `.bare`, so the call is correct from inside `main/` or any other linked worktree.
- Re-running the flagged command for a worktree that already exists hands that worktree to Herdr instead of failing, on the branch, detached and PR paths. Preserve, link and add hooks are not repeated, and the workspace lock is released before the handoff.
- A PR worktree is synced before the handoff so `--herdr` opens the current PR head and `--reset` keeps its meaning. When the sync is refused because the worktree holds uncommitted changes or local commits, Grove warns and opens it anyway; a sync that actually breaks still aborts rather than hand over a half-synced checkout.
- Both paths sent to Herdr are resolved, because git records a resolved path while Grove builds one from `os.Getwd`. Through a symlinked workspace root those spellings differ, which would otherwise make one worktree look like two workspaces.
- On the detached path an existing worktree is handed off only when its HEAD matches the requested ref, which is peeled to a commit so annotated tags compare correctly. A mismatch says so instead of reporting a stray directory.
- A failed handoff never rolls back the checkout. A missing binary and a non-zero Herdr exit give different errors, both naming the worktree, and only the first suggests installing `herdr`.
- `--herdr` with `--switch` is rejected: `--switch` reserves stdout for the shell wrapper's directory change.
- `herdr` is documented as an optional dependency alongside `gh`.

#### Decisions

- A refusal to sync is not a refusal to open. A worktree you are working in is dirty or ahead by definition, so `--herdr` warns and opens it; only a broken fetch, reset or fast-forward aborts, since those can leave the checkout half-synced.
- The PR number is recorded before the sync runs, because the identity holds whether or not the sync succeeds.
- Tests build their own symlinked root and their own dirty and unsynced worktrees. The shared helpers resolve symlinks and commit clean fixtures, so the suite cannot reach these paths otherwise.

#### Test plan

- [x] Code review by Claude Opus 5 (cape:code-reviewer) on 9f9f47c, findings addressed or dismissed
- [x] `make ci`
- [x] With a fake `herdr` on PATH, `grove add <branch> --herdr` from inside `main/` spawns `worktree open --cwd <root> --path <root>/<dir> --focus`
- [x] Re-running the same command exits 0, passes byte-identical argv, and leaves exactly one worktree
- [x] Against real Herdr 0.9.0, the first run creates the parent and grouped worktree workspaces; the re-run reuses the same workspace with its panes and scrollback intact
- [x] `grove add <branch>` without the flag spawns no `herdr` process
- [x] With `git` on PATH and `herdr` absent, the command exits non-zero, names the worktree, suggests PATH, and leaves the worktree usable
- [x] With `herdr` stubbed to exit 1, the error surfaces Herdr's output, names the worktree, omits the install hint, and the checkout survives
- [x] A dirty PR worktree and one with local commits both open, keep their work, and warn with the reason
- [x] A PR worktree whose fetch fails aborts and never reaches Herdr
- [x] Through a symlinked workspace root, both runs send one resolved identity
- [x] `grove add <branch> --herdr --switch` is rejected

---

Fixes ABU-371, AI-167